### PR TITLE
Add micro averaging to auroc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `CohenKappa` metric ([#69](https://github.com/PyTorchLightning/metrics/pull/69))
 
 
+- Added `average='micro'` as an option in auroc for multilabel problems ([#110](https://github.com/PyTorchLightning/metrics/pull/110))
+
+
 ### Changed
 
 - Changed `ExplainedVariance` from storing all preds/targets to tracking 5 statistics ([#68](https://github.com/PyTorchLightning/metrics/pull/68))

--- a/tests/classification/test_auroc.py
+++ b/tests/classification/test_auroc.py
@@ -92,7 +92,7 @@ def _sk_auroc_multilabel_multidim_prob(preds, target, num_classes, average='macr
      (_input_mlb_prob.preds, _input_mlb_prob.target, _sk_auroc_multilabel_prob, NUM_CLASSES),
      (_input_mlmd_prob.preds, _input_mlmd_prob.target, _sk_auroc_multilabel_multidim_prob, NUM_CLASSES)]
 )
-@pytest.mark.parametrize("average", ['macro', 'weighted'])
+@pytest.mark.parametrize("average", ['macro', 'weighted', 'micro'])
 @pytest.mark.parametrize("max_fpr", [None, 0.8, 0.5])
 class TestAUROC(MetricTester):
 
@@ -106,6 +106,10 @@ class TestAUROC(MetricTester):
         # max_fpr only supported for torch v1.6 or higher
         if max_fpr is not None and LooseVersion(torch.__version__) < LooseVersion('1.6.0'):
             pytest.skip('requires torch v1.6 or higher to test max_fpr argument')
+
+        # average='micro' only supported for multilabel
+        if average == 'micro' and preds.ndim > 2 and preds.ndim == target.ndim + 1:
+            pytest.skip('micro argument only support for multilabel input')
 
         self.run_class_metric_test(
             ddp=ddp,
@@ -129,6 +133,10 @@ class TestAUROC(MetricTester):
         # max_fpr only supported for torch v1.6 or higher
         if max_fpr is not None and LooseVersion(torch.__version__) < LooseVersion('1.6.0'):
             pytest.skip('requires torch v1.6 or higher to test max_fpr argument')
+
+        # average='micro' only supported for multilabel
+        if average == 'micro' and preds.ndim > 2 and preds.ndim == target.ndim + 1:
+            pytest.skip('micro argument only support for multilabel input')
 
         self.run_functional_metric_test(
             preds,

--- a/torchmetrics/classification/auroc.py
+++ b/torchmetrics/classification/auroc.py
@@ -48,6 +48,7 @@ class AUROC(Metric):
            this argument should not be set as we iteratively change it in the
            range [0,num_classes-1]
        average:
+           - ``'micro'`` computes metric globally. Only works for multilabel problems
            - ``'macro'`` computes metric for each class and uniformly averages them
            - ``'weighted'`` computes metric for each class and does a weighted-average,
              where each class is weighted by their support (accounts for class imbalance)

--- a/torchmetrics/classification/auroc.py
+++ b/torchmetrics/classification/auroc.py
@@ -110,7 +110,7 @@ class AUROC(Metric):
         self.average = average
         self.max_fpr = max_fpr
 
-        allowed_average = (None, 'macro', 'weighted')
+        allowed_average = (None, 'macro', 'weighted', 'micro')
         if self.average not in allowed_average:
             raise ValueError(
                 f'Argument `average` expected to be one of the following: {allowed_average} but got {average}'

--- a/torchmetrics/functional/classification/auroc.py
+++ b/torchmetrics/functional/classification/auroc.py
@@ -73,19 +73,24 @@ def _auroc_compute(
 
     # calculate fpr, tpr
     if mode == 'multi-label':
-        # for multilabel we iteratively evaluate roc in a binary fashion
-        output = [
-            roc(preds[:, i], target[:, i], num_classes=1, pos_label=1, sample_weights=sample_weights)
-            for i in range(num_classes)
-        ]
-        fpr = [o[0] for o in output]
-        tpr = [o[1] for o in output]
+        if average == AverageMethod.MICRO:
+            fpr, tpr, _ = roc(preds.flatten(), target.flatten(), num_classes, pos_label, sample_weights)
+        else:
+            # for multilabel we iteratively evaluate roc in a binary fashion
+            output = [
+                roc(preds[:, i], target[:, i], num_classes=1, pos_label=1, sample_weights=sample_weights)
+                for i in range(num_classes)
+            ]
+            fpr = [o[0] for o in output]
+            tpr = [o[1] for o in output]
     else:
         fpr, tpr, _ = roc(preds, target, num_classes, pos_label, sample_weights)
 
     # calculate standard roc auc score
     if max_fpr is None or max_fpr == 1:
-        if num_classes != 1:
+        if mode == 'multi-label' and average == AverageMethod.MICRO:
+            pass
+        elif num_classes != 1:
             # calculate auc scores per class
             auc_scores = [auc(x, y) for x, y in zip(fpr, tpr)]
 
@@ -149,6 +154,7 @@ def auroc(
             this argument should not be set as we iteratively change it in the
             range [0,num_classes-1]
         average:
+            - ``'micro'`` computes metric globally. Only works for multilabel problems
             - ``'macro'`` computes metric for each class and uniformly averages them
             - ``'weighted'`` computes metric for each class and does a weighted-average,
               where each class is weighted by their support (accounts for class imbalance)


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?
Fixes #104 
Adds option for `average='micro'` to `auroc` metric when running on `multilabel` data.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
