### PR TITLE
Bugfix: reset should set clear _computed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed when `_stable_1d_sort` to work when n >= N ([#6177](https://github.com/PyTorchLightning/pytorch-lightning/pull/6177))
 
 
-- Fixed `_computed` attibute not being correctly reset ([#147](https://github.com/PyTorchLightning/metrics/pull/147))
+- Fixed `_computed` attribute not being correctly reset ([#147](https://github.com/PyTorchLightning/metrics/pull/147))
 
 
 ## [0.2.0] - 2021-03-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed when `_stable_1d_sort` to work when n >= N ([#6177](https://github.com/PyTorchLightning/pytorch-lightning/pull/6177))
 
 
+- Fixed `_computed` attibute not being correctly reset ([#147](https://github.com/PyTorchLightning/metrics/pull/147))
+
+
 ## [0.2.0] - 2021-03-12
 
 

--- a/tests/bases/test_metric.py
+++ b/tests/bases/test_metric.py
@@ -95,6 +95,15 @@ def test_reset():
     assert isinstance(b.x, list) and len(b.x) == 0
 
 
+def test_reset_compute():
+    a = DummyMetricSum()
+    assert a.x == 0
+    a.update(tensor(5))
+    assert a.compute() == 5
+    a.reset()
+    assert a.compute() == 0
+
+
 def test_update():
 
     class A(DummyMetric):

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -254,6 +254,8 @@ class Metric(nn.Module, ABC):
         """
         This method automatically resets the metric state variables to their default value.
         """
+        self._computed = None
+
         for attr, default in self._defaults.items():
             current_val = getattr(self, attr)
             if isinstance(default, Tensor):


### PR DESCRIPTION
Fixing a small bug - reset not clearing computed cache value.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## Did you have fun?
Make sure you had fun coding 🙃
