### PR TITLE
Wrong parameters for MetricCollection example.

### DIFF
--- a/docs/source/pages/overview.rst
+++ b/docs/source/pages/overview.rst
@@ -240,7 +240,7 @@ inside your LightningModule
 
     class MyModule():
         def __init__(self):
-            metrics = MetricCollection(Accuracy(), Precision(), Recall())
+            metrics = MetricCollection([Accuracy(), Precision(), Recall()])
             self.train_metrics = metrics.clone(prefix='train_')
             self.valid_metrics = metrics.clone(prefix='val_')
 


### PR DESCRIPTION
From what i see from the other examples, there should only be a single metrics parameter for the MetricCollection, which could be List of Metric.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Fixes # (issue).

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
