### PR TITLE
allow MetricCollection with args

### DIFF
--- a/.github/workflows/ci_test-full.yml
+++ b/.github/workflows/ci_test-full.yml
@@ -6,11 +6,13 @@ on:  # Trigger the workflow on push or pull request, but only for the master bra
     branches: [master, "release/*"]
   pull_request:
     branches: [master, "release/*"]
+    types: [opened, reopened, ready_for_review, synchronize]
 
 jobs:
   pytest:
 
     runs-on: ${{ matrix.os }}
+    if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed behaviour of `confusionmatrix` for multilabel data to better match `multilabel_confusion_matrix` from sklearn ([#134](https://github.com/PyTorchLightning/metrics/pull/134))
 - Updated FBeta arguments ([#111](https://github.com/PyTorchLightning/metrics/pull/111))
 - Changed `reset` method to use `detach.clone()` instead of `deepcopy` when resetting to default ([#163](https://github.com/PyTorchLightning/metrics/pull/163))
+- Allowed `MetricCollection` pass metrics as arguments ([#176](https://github.com/PyTorchLightning/metrics/pull/176))
 
 ### Deprecated
 

--- a/tests/bases/test_average.py
+++ b/tests/bases/test_average.py
@@ -15,11 +15,13 @@ def average_ignore_weights(values, weights):
 
 
 class DefaultWeightWrapper(AverageMeter):
+
     def update(self, values, weights):
         super().update(values)
 
 
 class ScalarWrapper(AverageMeter):
+
     def update(self, values, weights):
         # torch.ravel is PyTorch 1.8 only, so use np.ravel instead
         values = values.cpu().numpy()
@@ -37,6 +39,7 @@ class ScalarWrapper(AverageMeter):
     ],
 )
 class TestAverageMeter(MetricTester):
+
     @pytest.mark.parametrize("ddp", [False, True])
     @pytest.mark.parametrize("dist_sync_on_step", [False, True])
     def test_average_fn(self, ddp, dist_sync_on_step, values, weights):

--- a/tests/bases/test_collections.py
+++ b/tests/bases/test_collections.py
@@ -85,23 +85,23 @@ def test_device_and_dtype_transfer_metriccollection(tmpdir):
 
 def test_metric_collection_wrong_input(tmpdir):
     """ Check that errors are raised on wrong input """
-    m1 = DummyMetricSum()
+    dms = DummyMetricSum()
 
     # Not all input are metrics (list)
     with pytest.raises(ValueError):
-        _ = MetricCollection([m1, 5])
+        _ = MetricCollection([dms, 5])
 
     # Not all input are metrics (dict)
     with pytest.raises(ValueError):
-        _ = MetricCollection({'metric1': m1, 'metric2': 5})
+        _ = MetricCollection({'metric1': dms, 'metric2': 5})
 
     # Same metric passed in multiple times
     with pytest.raises(ValueError, match='Encountered two metrics both named *.'):
-        _ = MetricCollection([m1, m1])
+        _ = MetricCollection([dms, dms])
 
     # Not a list or dict passed in
-    with pytest.raises(ValueError, match='Unknown input to MetricCollection.'):
-        _ = MetricCollection(m1)
+    with pytest.warns(Warning, match=' which are not `Metric` so they will be ignored.'):
+        _ = MetricCollection(dms, [dms])
 
 
 def test_metric_collection_args_kwargs(tmpdir):

--- a/torchmetrics/average.py
+++ b/torchmetrics/average.py
@@ -78,9 +78,7 @@ class AverageMeter(Metric):
 
     # TODO: need to be strings because Unions are not pickleable in Python 3.6
     def update(  # type: ignore
-        self,
-        value: "Union[Tensor, float]",
-        weight: "Union[Tensor, float]" = 1.0
+        self, value: "Union[Tensor, float]", weight: "Union[Tensor, float]" = 1.0
     ) -> None:
         """Updates the average with.
 

--- a/torchmetrics/classification/binned_precision_recall.py
+++ b/torchmetrics/classification/binned_precision_recall.py
@@ -157,13 +157,10 @@ class BinnedPrecisionRecallCurve(Metric):
         recalls = self.TPs / (self.TPs + self.FNs + METRIC_EPS)
 
         # Need to guarantee that last precision=1 and recall=0, similar to precision_recall_curve
-        precisions = torch.cat([
-            precisions, torch.ones(self.num_classes, 1, dtype=precisions.dtype, device=precisions.device)
-        ],
-            dim=1)
-        recalls = torch.cat([recalls,
-                             torch.zeros(self.num_classes, 1, dtype=recalls.dtype, device=recalls.device)],
-                            dim=1)
+        t_ones = torch.ones(self.num_classes, 1, dtype=precisions.dtype, device=precisions.device)
+        precisions = torch.cat([precisions, t_ones], dim=1)
+        t_zeros = torch.zeros(self.num_classes, 1, dtype=recalls.dtype, device=recalls.device)
+        recalls = torch.cat([recalls, t_zeros], dim=1)
         if self.num_classes == 1:
             return (precisions[0, :], recalls[0, :], self.thresholds)
         else:

--- a/torchmetrics/collections.py
+++ b/torchmetrics/collections.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, Tuple, Union, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from torch import nn
 
@@ -103,17 +103,13 @@ class MetricCollection(nn.ModuleDict):
             for name, metric in metrics.items():
                 if not isinstance(metric, Metric):
                     raise ValueError(
-                        f"Value {metric} belonging to key {name}"
-                        " is not an instance of `pl.metrics.Metric`"
+                        f"Value {metric} belonging to key {name} is not an instance of `pl.metrics.Metric`"
                     )
                 self[name] = metric
         elif isinstance(metrics, Sequence):
             for metric in metrics:
                 if not isinstance(metric, Metric):
-                    raise ValueError(
-                        f"Input {metric} to `MetricCollection` is not a instance"
-                        " of `pl.metrics.Metric`"
-                    )
+                    raise ValueError(f"Input {metric} to `MetricCollection` is not a instance of `pl.metrics.Metric`")
                 name = metric.__class__.__name__
                 if name in self:
                     raise ValueError(f"Encountered two metrics both named {name}")

--- a/torchmetrics/collections.py
+++ b/torchmetrics/collections.py
@@ -93,10 +93,7 @@ class MetricCollection(nn.ModuleDict):
             metrics = list(metrics)
             remain = []
             for m in additional_metrics:
-                if isinstance(m, Metric):
-                    metrics.append(m)
-                else:
-                    remain.append(m)
+                (metrics if isinstance(m, Metric) else remain).append(m)
 
             if remain:
                 rank_zero_warn(

--- a/torchmetrics/collections.py
+++ b/torchmetrics/collections.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Optional, Sequence, Union
 
 from torch import nn
 

--- a/torchmetrics/collections.py
+++ b/torchmetrics/collections.py
@@ -80,7 +80,7 @@ class MetricCollection(nn.ModuleDict):
     def __init__(
         self,
         metrics: Union[Metric, Sequence[Metric], Dict[str, Metric]],
-        *metric: Metric,
+        *additional_metrics: Metric,
         prefix: Optional[str] = None,
     ):
         super().__init__()
@@ -90,13 +90,17 @@ class MetricCollection(nn.ModuleDict):
         elif isinstance(metrics, Sequence):
             # prepare for optional additions
             metrics = list(metrics)
-        if metric:
-            metrics += [m for m in metric if isinstance(m, Metric)]
-            remain = [m for m in metric if not isinstance(m, Metric)]
-            if remain:
-                rank_zero_warn(
-                    f"You have passes extra arguments {remain} which are not `Metric` so they will be ignored."
-                )
+        remain = []
+        for m in additional_metrics:
+            if isinstance(m, Metric):
+                metrics.append(m)
+            else:
+                remain.append(m)
+                
+        if remain:
+            rank_zero_warn(
+                f"You have passes extra arguments {remain} which are not `Metric` so they will be ignored."
+            )
 
         if isinstance(metrics, dict):
             # Check all values are metrics


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?

Allow passing metrics as arguments...
```python
# Example (input as arguments):
metrics = MetricCollection(
    Accuracy(),
    Precision(num_classes=3, average='macro'),
    Recall(num_classes=3, average='macro'),
)
```
reaction to https://github.com/PyTorchLightning/metrics/pull/175#issuecomment-821945333

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
