### PR TITLE
Add postfix arg to MetricCollection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.4.0] - ????-??-??
-
-### Added
-
-- Added `postfix` arg to `MetricCollection` ([#188](https://github.com/PyTorchLightning/metrics/pull/188))
-
-### Changed
-
-
-### Deprecated
-
-
-### Removed
-
-
-### Fixed
-
 
 ## [0.3.0] - 2021-04-DD
 
@@ -51,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `__getitem__` as metric arithmetic operation ([#142](https://github.com/PyTorchLightning/metrics/pull/142))
 - Added property `is_differentiable` to metrics and test for differentiability ([#154](https://github.com/PyTorchLightning/metrics/pull/154))
 - Added support for `average`, `ignore_index` and `mdmc_average` in `Accuracy` metric ([#166](https://github.com/PyTorchLightning/metrics/pull/166))
+- Added `postfix` arg to `MetricCollection` ([#188](https://github.com/PyTorchLightning/metrics/pull/188))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - ????-??-??
+
+### Added
+
+- Added `postfix` arg to `MetricCollection` ([#188](https://github.com/PyTorchLightning/metrics/pull/188))
+
+### Changed
+
+
+### Deprecated
+
+
+### Removed
+
+
+### Fixed
+
 
 ## [0.3.0] - 2021-04-DD
 

--- a/tests/bases/test_collections.py
+++ b/tests/bases/test_collections.py
@@ -164,13 +164,13 @@ def test_metric_collection_prefix_postfix_args(prefix, postfix):
     # test clone
     new_metric_collection = metric_collection.clone(prefix='new_prefix_')
     out = new_metric_collection(5)
-    names = [n[7:] if prefix is not None else n for n in names]  # strip away old prefix
+    names = [n[len(prefix):] if prefix is not None else n for n in names]  # strip away old prefix
     for name in names:
         assert f"new_prefix_{name}" in out, 'prefix argument not working as intended with clone method'
 
     new_metric_collection = new_metric_collection.clone(postfix='_new_postfix')
     out = new_metric_collection(5)
-    names = [n[:-8] if postfix is not None else n for n in names]  # strip away old postfix
+    names = [n[:-len(postfix)] if postfix is not None else n for n in names]  # strip away old postfix
     for name in names:
         assert f"new_prefix_{name}_new_postfix" in out, 'postfix argument not working as intended with clone method'
 

--- a/tests/bases/test_collections.py
+++ b/tests/bases/test_collections.py
@@ -133,12 +133,14 @@ def test_metric_collection_args_kwargs(tmpdir):
     assert metric_collection['DummyMetricDiff'].x == -20
 
 
-@pytest.mark.parametrize("prefix, postfix", [
-    [None, None],
-    ['prefix_', None],
-    [None, '_postfix'],
-    ['prefix_', '_postfix']
-])
+@pytest.mark.parametrize(
+    "prefix, postfix", [
+        [None, None],
+        ['prefix_', None],
+        [None, '_postfix'],
+        ['prefix_', '_postfix'],
+    ]
+)
 def test_metric_collection_prefix_postfix_args(prefix, postfix):
     """ Test that the prefix arg alters the keywords in the output"""
     m1 = DummyMetricSum()

--- a/torchmetrics/__about__.py
+++ b/torchmetrics/__about__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.0rc0'
+__version__ = '0.3.0rc1'
 __author__ = 'PyTorchLightning et al.'
 __author_email__ = 'name@pytorchlightning.ai'
 __license__ = 'Apache-2.0'

--- a/torchmetrics/collections.py
+++ b/torchmetrics/collections.py
@@ -185,16 +185,15 @@ class MetricCollection(nn.ModuleDict):
         for _, m in self.items():
             m.persistent(mode)
 
-    def _set_name(self, k: str) -> str:
-        out = k if self.prefix is None else self.prefix + k
-        out = out if self.postfix is None else out + self.postfix
-        return out
+    def _set_name(self, base: str) -> str:
+        name = base if self.prefix is None else self.prefix + base
+        name = name if self.postfix is None else name + self.postfix
+        return name
 
     @staticmethod
     def _check_arg(arg: str, name: str) -> Optional[str]:
         if arg is not None:
             if isinstance(arg, str):
                 return arg
-            else:
-                raise ValueError(f'Expected input {name} to be a string')
+            raise ValueError(f'Expected input {name} to be a string')
         return None

--- a/torchmetrics/collections.py
+++ b/torchmetrics/collections.py
@@ -172,9 +172,9 @@ class MetricCollection(nn.ModuleDict):
 
         """
         mc = deepcopy(self)
-        if prefix is not None:
+        if prefix:
             mc.prefix = self._check_arg(prefix, 'prefix')
-        if postfix is not None:
+        if postfix:
             mc.postfix = self._check_arg(postfix, 'postfix')
         return mc
 

--- a/torchmetrics/collections.py
+++ b/torchmetrics/collections.py
@@ -168,7 +168,7 @@ class MetricCollection(nn.ModuleDict):
         """ Make a copy of the metric collection
         Args:
             prefix: a string to append in front of the metric keys
-            postfix: a string to append after the keys of the output dic
+            postfix: a string to append after the keys of the output dict
 
         """
         mc = deepcopy(self)

--- a/torchmetrics/collections.py
+++ b/torchmetrics/collections.py
@@ -38,6 +38,8 @@ class MetricCollection(nn.ModuleDict):
 
         prefix: a string to append in front of the keys of the output dict
 
+        postfix: a string to append after the keys of the output dict
+
     Raises:
         ValueError:
             If one of the elements of ``metrics`` is not an instance of ``pl.metrics.Metric``.
@@ -45,6 +47,10 @@ class MetricCollection(nn.ModuleDict):
             If two elements in ``metrics`` have the same ``name``.
         ValueError:
             If ``metrics`` is not a ``list``, ``tuple`` or a ``dict``.
+        ValueError:
+            If ``prefix`` is set and it is not a string
+        ValueError:
+            If ``postfix`` is set and it is not a string
 
     Example (input as list):
         >>> import torch
@@ -74,6 +80,7 @@ class MetricCollection(nn.ModuleDict):
         self,
         metrics: Union[List[Metric], Tuple[Metric], Dict[str, Metric]],
         prefix: Optional[str] = None,
+        postfix: Optional[str] = None
     ):
         super().__init__()
         if isinstance(metrics, dict):
@@ -99,7 +106,8 @@ class MetricCollection(nn.ModuleDict):
         else:
             raise ValueError("Unknown input to MetricCollection.")
 
-        self.prefix = self._check_prefix_arg(prefix)
+        self.prefix = self._check_arg(prefix, 'prefix')
+        self.postfix = self._check_arg(postfix, 'postfix')
 
     def forward(self, *args, **kwargs) -> Dict[str, Any]:  # pylint: disable=E0202
         """
@@ -107,7 +115,7 @@ class MetricCollection(nn.ModuleDict):
         be passed to every metric in the collection, while keyword arguments (kwargs)
         will be filtered based on the signature of the individual metric.
         """
-        return {self._set_prefix(k): m(*args, **m._filter_kwargs(**kwargs)) for k, m in self.items()}
+        return {self._set_name(k): m(*args, **m._filter_kwargs(**kwargs)) for k, m in self.items()}
 
     def update(self, *args, **kwargs):  # pylint: disable=E0202
         """
@@ -120,20 +128,25 @@ class MetricCollection(nn.ModuleDict):
             m.update(*args, **m_kwargs)
 
     def compute(self) -> Dict[str, Any]:
-        return {self._set_prefix(k): m.compute() for k, m in self.items()}
+        return {self._set_name(k): m.compute() for k, m in self.items()}
 
     def reset(self) -> None:
         """ Iteratively call reset for each metric """
         for _, m in self.items():
             m.reset()
 
-    def clone(self, prefix: Optional[str] = None) -> 'MetricCollection':
+    def clone(self, prefix: Optional[str] = None, postfix: Optional[str] = None) -> 'MetricCollection':
         """ Make a copy of the metric collection
         Args:
             prefix: a string to append in front of the metric keys
+            postfix: a string to append after the keys of the output dic
+
         """
         mc = deepcopy(self)
-        mc.prefix = self._check_prefix_arg(prefix)
+        if prefix is not None:
+            mc.prefix = self._check_arg(prefix, 'prefix')
+        if postfix is not None:
+            mc.postfix = self._check_arg(postfix, 'postfix')
         return mc
 
     def persistent(self, mode: bool = True) -> None:
@@ -143,14 +156,16 @@ class MetricCollection(nn.ModuleDict):
         for _, m in self.items():
             m.persistent(mode)
 
-    def _set_prefix(self, k: str) -> str:
-        return k if self.prefix is None else self.prefix + k
+    def _set_name(self, k: str) -> str:
+        out = k if self.prefix is None else self.prefix + k
+        out = out if self.postfix is None else out + self.postfix
+        return out
 
     @staticmethod
-    def _check_prefix_arg(prefix: str) -> Optional[str]:
-        if prefix is not None:
-            if isinstance(prefix, str):
-                return prefix
+    def _check_arg(arg: str, name: str) -> Optional[str]:
+        if arg is not None:
+            if isinstance(arg, str):
+                return arg
             else:
-                raise ValueError('Expected input `prefix` to be a string')
+                raise ValueError(f'Expected input {name} to be a string')
         return None


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  

## What does this PR do?
Fixes https://github.com/PyTorchLightning/metrics/issues/168
Adds a `postfix` arg that behaves similar to the `prefix` arg in metric collection. 

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
