### PR TITLE
Loads metric states from state_dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed auc calculation and add tests ([#197](https://github.com/PyTorchLightning/metrics/pull/197))
 
 
+- Fixed loading persisted metric states using `load_state_dict()` ([#202](https://github.com/PyTorchLightning/metrics/pull/202))
+
+
 ## [0.3.1] - 2021-04-21
 
 - Cleaning remaining inconsistency and fix PL develop integration (

--- a/tests/bases/test_metric.py
+++ b/tests/bases/test_metric.py
@@ -227,6 +227,16 @@ def test_state_dict(tmpdir):
     assert metric.state_dict() == OrderedDict()
 
 
+def test_load_state_dict(tmpdir):
+    """ test that metric states can be loaded with state dict """
+    metric = DummyMetricSum()
+    metric.persistent(True)
+    metric.update(5)
+    loaded_metric = DummyMetricSum()
+    loaded_metric.load_state_dict(metric.state_dict())
+    assert metric.compute() == 5
+
+
 def test_child_metric_state_dict():
     """ test that child metric states will be added to parent state dict """
 

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -324,6 +324,15 @@ class Metric(nn.Module, ABC):
                 destination[prefix + key] = current_val
         return destination
 
+    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
+                              missing_keys, unexpected_keys, error_msgs):
+        for key in self._defaults.keys():
+            name = prefix + key
+            if name in state_dict:
+                setattr(self, key, state_dict.pop(name))
+        super()._load_from_state_dict(state_dict, prefix, local_metadata, True,
+                                      missing_keys, unexpected_keys, error_msgs)
+
     def _filter_kwargs(self, **kwargs):
         """ filter kwargs such that they match the update signature of the metric """
 

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -17,7 +17,7 @@ import operator
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from copy import deepcopy
-from typing import Any, Callable, Optional, Union, List
+from typing import Any, Callable, List, Optional, Union
 
 import torch
 from torch import Tensor, nn

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -17,7 +17,7 @@ import operator
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from copy import deepcopy
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Optional, Union, List
 
 import torch
 from torch import Tensor, nn
@@ -324,15 +324,24 @@ class Metric(nn.Module, ABC):
                 destination[prefix + key] = current_val
         return destination
 
-    def _load_from_state_dict(self, state_dict: dict, prefix: str, local_metadata: dict, strict: bool,
-                              missing_keys: List[str], unexpected_keys: List[str], error_msgs: List[str]) -> None:
+    def _load_from_state_dict(
+        self,
+        state_dict: dict,
+        prefix: str,
+        local_metadata: dict,
+        strict: bool,
+        missing_keys: List[str],
+        unexpected_keys: List[str],
+        error_msgs: List[str],
+    ) -> None:
         """ Loads metric states from state_dict """
         for key in self._defaults.keys():
             name = prefix + key
             if name in state_dict:
                 setattr(self, key, state_dict.pop(name))
-        super()._load_from_state_dict(state_dict, prefix, local_metadata, True,
-                                      missing_keys, unexpected_keys, error_msgs)
+        super()._load_from_state_dict(
+            state_dict, prefix, local_metadata, True, missing_keys, unexpected_keys, error_msgs
+        )
 
     def _filter_kwargs(self, **kwargs):
         """ filter kwargs such that they match the update signature of the metric """

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -326,6 +326,7 @@ class Metric(nn.Module, ABC):
 
     def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
                               missing_keys, unexpected_keys, error_msgs):
+        """ Loads metric states from state_dict """
         for key in self._defaults.keys():
             name = prefix + key
             if name in state_dict:

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -324,8 +324,8 @@ class Metric(nn.Module, ABC):
                 destination[prefix + key] = current_val
         return destination
 
-    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
+    def _load_from_state_dict(self, state_dict: dict, prefix: str, local_metadata: dict, strict: bool,
+                              missing_keys: List[str], unexpected_keys: List[str], error_msgs: List[str]) -> None:
         """ Loads metric states from state_dict """
         for key in self._defaults.keys():
             name = prefix + key


### PR DESCRIPTION
The persistent metric states are output in `state_dict`, but cannot be properly loaded through `load_state_dict()`. This PR adds handling to loading persisted metric states from `state_dict` and a unit test.
