### PR TITLE
Improve AUC numeric stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `PSNR` not working with `DDP` ([#214](https://github.com/PyTorchLightning/metrics/pull/214))
 
 
+- Fixed `AUC` sometimes raises errors even for sorted imput due to numerical instability ([#224](https://github.com/PyTorchLightning/metrics/pull/224))
+
+
 ## [0.3.1] - 2021-04-21
 
 - Cleaning remaining inconsistency and fix PL develop integration (

--- a/torchmetrics/functional/classification/auc.py
+++ b/torchmetrics/functional/classification/auc.py
@@ -31,7 +31,7 @@ def _auc_update(x: Tensor, y: Tensor) -> Tuple[Tensor, Tensor]:
     return x, y
 
 
-def _auc_compute(x: Tensor, y: Tensor, reorder: bool = False) -> Tensor:
+def _auc_compute(x: Tensor, y: Tensor, reorder: bool = False, tol: float = 1e-6) -> Tensor:
     with torch.no_grad():
         if reorder:
             # TODO: include stable=True arg when pytorch v1.9 is released
@@ -40,7 +40,7 @@ def _auc_compute(x: Tensor, y: Tensor, reorder: bool = False) -> Tensor:
 
         dx = x[1:] - x[:-1]
         if (dx < 0).any():
-            if (dx <= 0).all():
+            if (dx <= tol).all():
                 direction = -1.
             else:
                 raise ValueError(

--- a/torchmetrics/functional/classification/auc.py
+++ b/torchmetrics/functional/classification/auc.py
@@ -39,7 +39,7 @@ def _auc_compute(x: Tensor, y: Tensor, reorder: bool = False, tol: float = 1e-6)
             y = y[x_idx]
 
         dx = x[1:] - x[:-1]
-        if (dx+tol < 0).any():
+        if (dx + tol < 0).any():
             if (dx <= tol).all():
                 direction = -1.
             else:

--- a/torchmetrics/functional/classification/auc.py
+++ b/torchmetrics/functional/classification/auc.py
@@ -39,7 +39,7 @@ def _auc_compute(x: Tensor, y: Tensor, reorder: bool = False, tol: float = 1e-6)
             y = y[x_idx]
 
         dx = x[1:] - x[:-1]
-        if (dx < 0).any():
+        if (dx+tol < 0).any():
             if (dx <= tol).all():
                 direction = -1.
             else:


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Fixes https://github.com/PyTorchLightning/metrics/discussions/219
In rare case when the input is very large, the `dx` here
https://github.com/PyTorchLightning/metrics/blob/cb6899bb47c7d30f8626d6ef8c28cc29efce82d6/torchmetrics/functional/classification/auc.py#L41-L49
will even for monotone increasing/decreasing (input that is already sorted) result in a mix of positive and negative errors making the algorithm raise the error. This happens when `x[i]` and `x[i+1]` is the same number but due to numerical stability `x[i+1]-x[i]` will randomly either be a small negative or positive number.

This PR solves it by adding a small tolerance to the checks.

I checked with the provided repo/script in the discussion that it correctly solves the error.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
