### PR TITLE
Add differentiability testing to more metrics [3/n]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `is_differentiable` property:
     * To `AUC`, `AUROC`, `CohenKappa` and `AveragePrecision` ([#178](https://github.com/PyTorchLightning/metrics/pull/178))
-    * To `PearsonCorrCoef`, `SpearmanCorrcoef`, `R2Score` and `ExplainedVariance` ([]())
+    * To `PearsonCorrCoef`, `SpearmanCorrcoef`, `R2Score` and `ExplainedVariance` ([#225](https://github.com/PyTorchLightning/metrics/pull/225))
 
 - Added `add_metrics` method to `MetricCollection` for adding additional metrics after initialization ([#221](https://github.com/PyTorchLightning/metrics/pull/221))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Specificity metric ([#210](https://github.com/PyTorchLightning/metrics/pull/210))
 
 
-- Added `is_differentiable` property to `AUC`, `AUROC`, `CohenKappa` and `AveragePrecision` ([#178](https://github.com/PyTorchLightning/metrics/pull/178))
-
+- Added `is_differentiable` property:
+    * To `AUC`, `AUROC`, `CohenKappa` and `AveragePrecision` ([#178](https://github.com/PyTorchLightning/metrics/pull/178))
+    * To `PearsonCorrCoef`, `SpearmanCorrcoef`, `R2Score` and `ExplainedVariance` ([]())
 
 - Added `add_metrics` method to `MetricCollection` for adding additional metrics after initialization ([#221](https://github.com/PyTorchLightning/metrics/pull/221))
 
 
 - Added pre-gather reduction in the case of `dist_reduce_fx="cat"` to reduce communication cost ([#217](https://github.com/PyTorchLightning/metrics/pull/217))
+
 
 
 ### Changed

--- a/tests/regression/test_explained_variance.py
+++ b/tests/regression/test_explained_variance.py
@@ -85,6 +85,12 @@ class TestExplainedVariance(MetricTester):
             metric_args=dict(multioutput=multioutput),
         )
 
+    def test_explained_variance_differentiability(self, multioutput, preds, target, sk_metric):
+        self.run_differentiability_test(
+            preds=preds, target=target, metric_module=ExplainedVariance, metric_functional=explained_variance,
+            metric_args={'multioutput': multioutput}
+        )
+
     @pytest.mark.skipif(
         not _TORCH_GREATER_EQUAL_1_6, reason='half support of core operations on not support before pytorch v1.6'
     )

--- a/tests/regression/test_pearson.py
+++ b/tests/regression/test_pearson.py
@@ -69,6 +69,11 @@ class TestPearsonCorrcoef(MetricTester):
             preds=preds, target=target, metric_functional=pearson_corrcoef, sk_metric=_sk_pearsonr
         )
 
+    def test_pearson_corrcoef_differentiability(self, preds, target):
+        self.run_differentiability_test(
+            preds=preds, target=target, metric_module=PearsonCorrcoef, metric_functional=pearson_corrcoef
+        )
+
     # Pearson half + cpu does not work due to missing support in torch.sqrt
     @pytest.mark.xfail(reason="PearsonCorrcoef metric does not support cpu + half precision")
     def test_pearson_corrcoef_half_cpu(self, preds, target):

--- a/tests/regression/test_r2score.py
+++ b/tests/regression/test_r2score.py
@@ -93,6 +93,12 @@ class TestR2Score(MetricTester):
             metric_args=dict(adjusted=adjusted, multioutput=multioutput),
         )
 
+    def test_r2_differentiabilit(self, adjusted, multioutput, preds, target, sk_metric, num_outputs):
+        self.run_differentiability_test(
+            preds=preds, target=target, metric_module=partial(R2Score, num_outputs=num_outputs),
+            metric_functional=r2score, metric_args=dict(adjusted=adjusted, multioutput=multioutput)
+        )
+
     @pytest.mark.skipif(
         not _TORCH_GREATER_EQUAL_1_6, reason='half support of core operations on not support before pytorch v1.6'
     )

--- a/tests/regression/test_spearman.py
+++ b/tests/regression/test_spearman.py
@@ -82,6 +82,11 @@ class TestSpearmanCorrcoef(MetricTester):
     def test_spearman_corrcoef_functional(self, preds, target):
         self.run_functional_metric_test(preds, target, spearman_corrcoef, _sk_metric)
 
+    def test_spearman_corrcoef_differentiability(self, preds, target):
+        self.run_differentiability_test(
+            preds=preds, target=target, metric_module=SpearmanCorrcoef, metric_functional=spearman_corrcoef
+        )
+
     # Spearman half + cpu does not work due to missing support in torch.arange
     @pytest.mark.xfail(reason="Spearman metric does not support cpu + half precision")
     def test_spearman_corrcoef_half_cpu(self, preds, target):

--- a/torchmetrics/regression/explained_variance.py
+++ b/torchmetrics/regression/explained_variance.py
@@ -131,3 +131,7 @@ class ExplainedVariance(Metric):
             self.sum_squared_target,
             self.multioutput,
         )
+
+    @property
+    def is_differentiable(self):
+        return True

--- a/torchmetrics/regression/pearson.py
+++ b/torchmetrics/regression/pearson.py
@@ -96,3 +96,7 @@ class PearsonCorrcoef(Metric):
         preds = dim_zero_cat(self.preds)
         target = dim_zero_cat(self.target)
         return _pearson_corrcoef_compute(preds, target)
+
+    @property
+    def is_differentiable(self):
+        return True

--- a/torchmetrics/regression/r2score.py
+++ b/torchmetrics/regression/r2score.py
@@ -145,3 +145,7 @@ class R2Score(Metric):
         return _r2score_compute(
             self.sum_squared_error, self.sum_error, self.residual, self.total, self.adjusted, self.multioutput
         )
+
+    @property
+    def is_differentiable(self):
+        return True

--- a/torchmetrics/regression/spearman.py
+++ b/torchmetrics/regression/spearman.py
@@ -94,3 +94,7 @@ class SpearmanCorrcoef(Metric):
         preds = dim_zero_cat(self.preds)
         target = dim_zero_cat(self.target)
         return _spearman_corrcoef_compute(preds, target)
+
+    @property
+    def is_differentiable(self):
+        return False


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Last PR: https://github.com/PyTorchLightning/metrics/pull/178
Adds the `is_differentiable` to more metrics and corresponding testing

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
