### PR TITLE
Ports are reused breaking parallel tests

### DIFF
--- a/tests/helpers/testers.py
+++ b/tests/helpers/testers.py
@@ -41,6 +41,7 @@ MAX_PORT = 8100
 START_PORT = 8088
 CURRENT_PORT = START_PORT
 
+
 def setup_ddp(rank, world_size):
     """ Setup ddp environment """
     global CURRENT_PORT

--- a/tests/helpers/testers.py
+++ b/tests/helpers/testers.py
@@ -37,11 +37,20 @@ NUM_CLASSES = 5
 EXTRA_DIM = 3
 THRESHOLD = 0.5
 
+MAX_PORT = 8100
+START_PORT = 8088
+CURRENT_PORT = START_PORT
 
 def setup_ddp(rank, world_size):
     """ Setup ddp environment """
+    global CURRENT_PORT
+
     os.environ["MASTER_ADDR"] = "localhost"
-    os.environ["MASTER_PORT"] = "8088"
+    os.environ["MASTER_PORT"] = str(CURRENT_PORT)
+
+    CURRENT_PORT += 1
+    if CURRENT_PORT > MAX_PORT:
+        CURRENT_PORT = START_PORT
 
     if torch.distributed.is_available() and sys.platform not in ("win32", "cygwin"):
         torch.distributed.init_process_group("gloo", rank=rank, world_size=world_size)


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Reusing the same port in tests breaks them if they are being run in parallel. This is a simple fix that cycles through ports between 8088 (current one) and 8100, submitting PR to trigger CI tests

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
