### PR TITLE
Fix concatenation of zero dim states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed metric calculation with unequal batch sizes ([#220](https://github.com/PyTorchLightning/metrics/pull/220))
 
 
-- Fixed metric concatenation for list states for zero-dim input ([]())
+- Fixed metric concatenation for list states for zero-dim input ([#229](https://github.com/PyTorchLightning/metrics/pull/229))
 
 
 ## [0.3.1] - 2021-04-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed metric calculation with unequal batch sizes ([#220](https://github.com/PyTorchLightning/metrics/pull/220))
 
 
+- Fixed metric concatenation for list states for zero-dim input ([]())
+
+
 ## [0.3.1] - 2021-04-21
 
 - Cleaning remaining inconsistency and fix PL develop integration (

--- a/torchmetrics/functional/regression/spearman.py
+++ b/torchmetrics/functional/regression/spearman.py
@@ -59,10 +59,10 @@ def _spearman_corrcoef_update(preds: Tensor, target: Tensor) -> Tuple[Tensor, Te
             f" Got preds: {preds.dtype} and target: {target.dtype}."
         )
     _check_same_shape(preds, target)
-
+    preds = preds.squeeze()
+    target = target.squeeze()
     if preds.ndim > 1 or target.ndim > 1:
         raise ValueError('Expected both predictions and target to be 1 dimensional tensors.')
-
     return preds, target
 
 

--- a/torchmetrics/utilities/data.py
+++ b/torchmetrics/utilities/data.py
@@ -21,16 +21,17 @@ from torchmetrics.utilities.prints import rank_zero_warn
 METRIC_EPS = 1e-6
 
 
-def dim_zero_cat(x):
+def dim_zero_cat(x: Union[Tensor, List[Tensor]]) -> Tensor:
     x = x if isinstance(x, (list, tuple)) else [x]
+    x = [xx.unsqueeze(0) if xx.numel() == 1 and xx.ndim == 0 else xx for xx in x]
     return torch.cat(x, dim=0)
 
 
-def dim_zero_sum(x):
+def dim_zero_sum(x: Tensor) -> Tensor:
     return torch.sum(x, dim=0)
 
 
-def dim_zero_mean(x):
+def dim_zero_mean(x: Tensor) -> Tensor:
     return torch.mean(x, dim=0)
 
 

--- a/torchmetrics/utilities/data.py
+++ b/torchmetrics/utilities/data.py
@@ -23,7 +23,7 @@ METRIC_EPS = 1e-6
 
 def dim_zero_cat(x: Union[Tensor, List[Tensor]]) -> Tensor:
     x = x if isinstance(x, (list, tuple)) else [x]
-    x = [xx.unsqueeze(0) if xx.numel() == 1 and xx.ndim == 0 else xx for xx in x]
+    x = [y.unsqueeze(0) if y.numel() == 1 and y.ndim == 0 else y for y in x]
     return torch.cat(x, dim=0)
 
 


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Fixes https://github.com/PyTorchLightning/metrics/issues/227
Makes sure that metrics that use list as state can take in 0 dim input and the concatenation still works.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
