### PR TITLE
Fix dtype incorrectly being reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - AUC can also support more dimensional inputs when all but one dimensions are of size 1 ([#242](https://github.com/PyTorchLightning/metrics/pull/242))
 
-
+- Fixed dtype of modular metrics after reset have been called ([]())
 
 ## [0.3.2] - 2021-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - AUC can also support more dimensional inputs when all but one dimensions are of size 1 ([#242](https://github.com/PyTorchLightning/metrics/pull/242))
 
-- Fixed dtype of modular metrics after reset have been called ([]())
+- Fixed dtype of modular metrics after reset have been called ([#243](https://github.com/PyTorchLightning/metrics/pull/243))
 
 ## [0.3.2] - 2021-05-10
 

--- a/tests/bases/test_metric.py
+++ b/tests/bases/test_metric.py
@@ -269,8 +269,12 @@ def test_device_and_dtype_transfer(tmpdir):
 
     metric = metric.double()
     assert metric.x.dtype == torch.float64
+    metric.reset()
+    assert metric.x.dtype == torch.float64
 
     metric = metric.half()
+    assert metric.x.dtype == torch.float16
+    metric.reset()
     assert metric.x.dtype == torch.float16
 
 

--- a/torchmetrics/functional/classification/cohen_kappa.py
+++ b/torchmetrics/functional/classification/cohen_kappa.py
@@ -23,6 +23,7 @@ _cohen_kappa_update = _confusion_matrix_update
 
 def _cohen_kappa_compute(confmat: Tensor, weights: Optional[str] = None) -> Tensor:
     confmat = _confusion_matrix_compute(confmat)
+    confmat = confmat.float() if not confmat.is_floating_point() else confmat
     n_classes = confmat.shape[0]
     sum0 = confmat.sum(dim=0, keepdim=True)
     sum1 = confmat.sum(dim=1, keepdim=True)

--- a/torchmetrics/functional/classification/confusion_matrix.py
+++ b/torchmetrics/functional/classification/confusion_matrix.py
@@ -47,8 +47,8 @@ def _confusion_matrix_compute(confmat: Tensor, normalize: Optional[str] = None) 
     allowed_normalize = ('true', 'pred', 'all', 'none', None)
     assert normalize in allowed_normalize, \
         f"Argument average needs to one of the following: {allowed_normalize}"
-    confmat = confmat.float() if not confmat.is_floating_point() else confmat
     if normalize is not None and normalize != 'none':
+        confmat = confmat.float() if not confmat.is_floating_point() else confmat
         cm = None
         if normalize == 'true':
             cm = confmat / confmat.sum(axis=1, keepdim=True)

--- a/torchmetrics/functional/classification/confusion_matrix.py
+++ b/torchmetrics/functional/classification/confusion_matrix.py
@@ -28,7 +28,6 @@ def _confusion_matrix_update(
     if mode not in (DataType.BINARY, DataType.MULTILABEL):
         preds = preds.argmax(dim=1)
         target = target.argmax(dim=1)
-
     if multilabel:
         unique_mapping = ((2 * target + preds) + 4 * torch.arange(num_classes, device=preds.device)).flatten()
         minlength = 4 * num_classes
@@ -48,7 +47,7 @@ def _confusion_matrix_compute(confmat: Tensor, normalize: Optional[str] = None) 
     allowed_normalize = ('true', 'pred', 'all', 'none', None)
     assert normalize in allowed_normalize, \
         f"Argument average needs to one of the following: {allowed_normalize}"
-    confmat = confmat.float()
+    confmat = confmat.float() if not confmat.is_floating_point() else confmat
     if normalize is not None and normalize != 'none':
         cm = None
         if normalize == 'true':

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -312,8 +312,13 @@ class Metric(nn.Module, ABC):
         to the correct device when `.to`, `.cuda`, etc methods are called
         """
         this = super()._apply(fn)
-        # Also apply fn to metric states
-        for key in this._defaults.keys():
+        # Also apply fn to metric states and defaults
+        for key, value in this._defaults.items():
+            if isinstance(value, Tensor):
+                this._defaults[key] = fn(value)
+            elif isinstance(value, Sequence):
+                this._defaults[key] = [fn(v) for v in value]
+
             current_val = getattr(this, key)
             if isinstance(current_val, Tensor):
                 setattr(this, key, fn(current_val))


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Fixes #187
Currently, if a module is casted to another dtype, say double
```python
c = ConfusionMatrix(num_classes=3).double()
```
the initial metric states are correctly moved to `double` dtype. However, since currently is not applied to the `_defaults` (which contains the values we reset metric states to) after calling `reset` once the states will be back to whatever dtype they where original initialized with in `self.add_state`.
This PR fixes this and a bug in relation to this inside `ConfusionMatrix` that always forces the input to be float (even if asking for double).


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
