### PR TITLE
[feat] Add `reset_forward_cache` to Metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Forward cache is now reset when `reset` method is called ([#260](https://github.com/PyTorchLightning/metrics/pull/260))
 
 ### Deprecated
 

--- a/tests/bases/test_metric.py
+++ b/tests/bases/test_metric.py
@@ -303,3 +303,11 @@ def test_warning_on_compute_before_update():
 def test_metric_scripts():
     torch.jit.script(DummyMetric())
     torch.jit.script(DummyMetricSum())
+
+
+def test_metric_forward_cache_reset():
+    metric = DummyMetricSum()
+    _ = metric(2.0)
+    assert metric._forward_cache == 2.0
+    metric.reset()
+    assert metric._forward_cache is None

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -59,8 +59,6 @@ class Metric(nn.Module, ABC):
         dist_sync_fn:
             Callback that performs the allgather operation on the metric state. When `None`, DDP
             will be used to perform the allgather.
-        reset_forward_cache:
-            Wether to reset `forward_cache` after update when `dist_sync_on_step` is False.
     """
 
     __jit_ignored_attributes__ = ["is_differentiable"]
@@ -85,7 +83,6 @@ class Metric(nn.Module, ABC):
         self.compute_on_step = compute_on_step
         self.process_group = process_group
         self.dist_sync_fn = dist_sync_fn
-        self.reset_forward_cache = reset_forward_cache
         self._to_sync = True
 
         self._update_signature = inspect.signature(self.update)
@@ -170,9 +167,6 @@ class Metric(nn.Module, ABC):
         # add current step
         with torch.no_grad():
             self.update(*args, **kwargs)
-
-        if self.reset_forward_cache:
-            self._forward_cache = None
 
         if self.compute_on_step:
             self._to_sync = self.dist_sync_on_step
@@ -288,6 +282,7 @@ class Metric(nn.Module, ABC):
         This method automatically resets the metric state variables to their default value.
         """
         self._update_called = False
+        self._forward_cache = None
         # lower lightning versions requires this implicitly to log metric objects correctly in self.log
         if not _LIGHTNING_AVAILABLE or self._LIGHTNING_GREATER_EQUAL_1_3:
             self._computed = None

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -69,7 +69,6 @@ class Metric(nn.Module, ABC):
         dist_sync_on_step: bool = False,
         process_group: Optional[Any] = None,
         dist_sync_fn: Callable = None,
-        reset_forward_cache: bool = True,
     ):
         super().__init__()
 


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?

This PR adds `reset_forward_cache` option to Metric.

When wrapping Metric in Metric, the `forward_cache` get overridden. This option enables to get skip this.

This would be used in Logging Refactor in Lightning: https://github.com/PyTorchLightning/pytorch-lightning/pull/7631

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
