### PR TITLE
Note on DP and Lightning use

### DIFF
--- a/docs/source/pages/overview.rst
+++ b/docs/source/pages/overview.rst
@@ -126,7 +126,7 @@ Addtionally, if metrics are used together with a `LightningModule` the metric up
 in the ``<mode>_step_end`` method (where ``<mode>`` is either ``training``, ``validation`` or ``test``), else
 it will lead to wrong accumulation. In practice do the following:
 
-.. code-block:: python
+.. testcode::
 
     def training_step(self, batch, batch_idx):
         data, target = batch

--- a/docs/source/pages/overview.rst
+++ b/docs/source/pages/overview.rst
@@ -122,6 +122,23 @@ This has the consequence, that the metric state of the replicas will as default 
 them. It is therefore recommended, when using metrics in DP mode, to initialize them with ``dist_sync_on_step=True``
 such that metric states are synchonized between the main process and the replicas before they are destroyed.
 
+Addtionally, if metrics are used together with a `LightningModule` the metric update/logging should be done
+in the ``<mode>_step_end`` method (where ``<mode>`` is either ``training``, ``validation`` or ``test``), else
+it will lead to wrong accumulation. In practice do the following:
+
+.. code-block:: python
+
+    def training_step(self, batch, batch_idx):
+        data, target = batch
+        preds = self(data)
+        ...
+        return {'loss' : loss, 'preds' : preds, 'target' : target}
+
+    def training_step_end(self, outputs):
+        #update and log
+        self.metric(outputs['preds'], outputs['target'])
+        self.log('metric', self.metric)
+
 Metrics in Distributed Data Parallel (DDP) mode
 ===============================================
 


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Fixes #266 
Re-adds a note that got lost in the repo transfer (taken from this file https://github.com/PyTorchLightning/pytorch-lightning/blob/1.2.1/docs/source/extensions/metrics.rst) that metric update in dp mode should happen in the `training_step_end` method.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
