### PR TITLE
Add torch.jit.unused to MetricCollection forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved per-class metric handling for imbalanced datasets for `precision`, `recall`, `precision_recall`, `fbeta`, `f1`, `accuracy`, and `specificity` ([#204](https://github.com/PyTorchLightning/metrics/pull/204))
 
 
+- Added `torch.jit.unused` to `MetricCollection` forward ([#307](https://github.com/PyTorchLightning/metrics/pull/307))
+
+
 ### Deprecated
 
 - Remove `torchmetrics.functional.mean_relative_error`([#248](https://github.com/PyTorchLightning/metrics/pull/248))

--- a/torchmetrics/collections.py
+++ b/torchmetrics/collections.py
@@ -16,6 +16,7 @@ from collections import OrderedDict
 from copy import deepcopy
 from typing import Any, Dict, Iterable, Optional, Sequence, Tuple, Union
 
+import torch
 from torch import nn
 
 from torchmetrics.metric import Metric
@@ -101,6 +102,7 @@ class MetricCollection(nn.ModuleDict):
         self.prefix = self._check_arg(prefix, 'prefix')
         self.postfix = self._check_arg(postfix, 'postfix')
 
+    @torch.jit.unused
     def forward(self, *args, **kwargs) -> Dict[str, Any]:  # pylint: disable=E0202
         """
         Iteratively call forward for each metric. Positional arguments (args) will


### PR DESCRIPTION
# Before submitting

- [NA] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [NA] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
The forward function of MetricCollection has *args and **kwargs arguments. Which aren't jit supported. Add torch.jit.unused decorator.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
