### PR TITLE
Fix code to correspond to equation for  matthews_corrcoef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - AUC can also support more dimensional inputs when all but one dimension are of size 1 ([#242](https://github.com/PyTorchLightning/metrics/pull/242))
 - Fixed `dtype` of modular metrics after reset has been called ([#243](https://github.com/PyTorchLightning/metrics/pull/243))
-
+- Fixed calculation in `matthews_corrcoef` to correctly match formula (())
 
 ## [0.3.2] - 2021-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - AUC can also support more dimensional inputs when all but one dimension are of size 1 ([#242](https://github.com/PyTorchLightning/metrics/pull/242))
 - Fixed `dtype` of modular metrics after reset has been called ([#243](https://github.com/PyTorchLightning/metrics/pull/243))
-- Fixed calculation in `matthews_corrcoef` to correctly match formula (())
+- Fixed calculation in `matthews_corrcoef` to correctly match formula ([#321](https://github.com/PyTorchLightning/metrics/pull/321))
 
 ## [0.3.2] - 2021-05-10
 

--- a/torchmetrics/functional/classification/matthews_corrcoef.py
+++ b/torchmetrics/functional/classification/matthews_corrcoef.py
@@ -20,8 +20,8 @@ _matthews_corrcoef_update = _confusion_matrix_update
 
 
 def _matthews_corrcoef_compute(confmat: Tensor) -> Tensor:
-    tk = confmat.sum(dim=0).float()
-    pk = confmat.sum(dim=1).float()
+    tk = confmat.sum(dim=1).float()
+    pk = confmat.sum(dim=0).float()
     c = torch.trace(confmat).float()
     s = confmat.sum().float()
     return (c * s - sum(tk * pk)) / (torch.sqrt(s**2 - sum(pk * pk)) * torch.sqrt(s**2 - sum(tk * tk)))


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Fixes https://github.com/PyTorchLightning/metrics/issues/320
Currently there is a small mismatch between the definition of matthews corrcoef and our code. The code was still correct because the equation is symmetrical, but as requested by an user our code should match the definition. PR fixes this.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
