### PR TITLE
Fix latex subscripts in R2Score docstrings

### DIFF
--- a/torchmetrics/functional/regression/r2.py
+++ b/torchmetrics/functional/regression/r2.py
@@ -120,13 +120,13 @@ def r2_score(
     r"""
     Computes r2 score also known as `coefficient of determination`_:
 
-    .. math:: R^2 = 1 - \frac{SS_res}{SS_tot}
+    .. math:: R^2 = 1 - \frac{SS_{res}}{SS_{tot}}
 
-    where :math:`SS_res=\sum_i (y_i - f(x_i))^2` is the sum of residual squares, and
-    :math:`SS_tot=\sum_i (y_i - \bar{y})^2` is total sum of squares. Can also calculate
+    where :math:`SS_{res}=\sum_i (y_i - f(x_i))^2` is the sum of residual squares, and
+    :math:`SS_{tot}=\sum_i (y_i - \bar{y})^2` is total sum of squares. Can also calculate
     adjusted r2 score given by
 
-    .. math:: R^2_adj = 1 - \frac{(1-R^2)(n-1)}{n-k-1}
+    .. math:: R^2_{adj} = 1 - \frac{(1-R^2)(n-1)}{n-k-1}
 
     where the parameter :math:`k` (the number of independent regressors) should
     be provided as the ``adjusted`` argument.

--- a/torchmetrics/regression/r2.py
+++ b/torchmetrics/regression/r2.py
@@ -24,13 +24,13 @@ class R2Score(Metric):
     r"""
     Computes r2 score also known as `coefficient of determination`_:
 
-    .. math:: R^2 = 1 - \frac{SS_res}{SS_tot}
+    .. math:: R^2 = 1 - \frac{SS_{res}}{SS_{tot}}
 
-    where :math:`SS_res=\sum_i (y_i - f(x_i))^2` is the sum of residual squares, and
-    :math:`SS_tot=\sum_i (y_i - \bar{y})^2` is total sum of squares. Can also calculate
+    where :math:`SS_{res}=\sum_i (y_i - f(x_i))^2` is the sum of residual squares, and
+    :math:`SS_{tot}=\sum_i (y_i - \bar{y})^2` is total sum of squares. Can also calculate
     adjusted r2 score given by
 
-    .. math:: R^2_adj = 1 - \frac{(1-R^2)(n-1)}{n-k-1}
+    .. math:: R^2_{adj} = 1 - \frac{(1-R^2)(n-1)}{n-k-1}
 
     where the parameter :math:`k` (the number of independent regressors) should
     be provided as the `adjusted` argument.


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?

Fixes latex subscripts in R2Score docstrings.
- Old broken docs:
  <img width="873" alt="image" src="https://user-images.githubusercontent.com/1733389/128057931-04d6e701-9146-48eb-a2b0-dd0ddd73a6f5.png">
- New docs:
  <img width="865" alt="image" src="https://user-images.githubusercontent.com/1733389/128065313-987f1518-8e0e-4abd-b14d-607acfb3eb5b.png">



## PR review

TODO

## Did you have fun?

Yes.
