### PR TITLE
Use __jit_unused_properties__ for is_differentiable

### DIFF
--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -67,7 +67,8 @@ class Metric(nn.Module, ABC):
             will be used to perform the allgather.
     """
 
-    __jit_ignored_attributes__ = ["is_differentiable", "device", "dtype"]
+    __jit_ignored_attributes__ = ["device", "dtype"]
+    __jit_unused_properties__ = ["is_differentiable"]
 
     def __init__(
         self,


### PR DESCRIPTION
`is_differentiable` is a property on the Metric class. Therefore, we need to use the property marker instead of the attribute marker for JIT
Reference: This matches what Lightning does here: https://github.com/PyTorchLightning/pytorch-lightning/blob/f3442db3f0155a32c8bc0ca3bc943d4b0039897f/pytorch_lightning/core/lightning.py#L67-L86

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?

Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
