### PR TITLE
Add mean average precision metric for object detection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy>=1.17.2
 torch>=1.3.1
+pycocotools>=2.0.2
 packaging

--- a/tests/image/test_map.py
+++ b/tests/image/test_map.py
@@ -1,0 +1,101 @@
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import namedtuple
+
+import torch
+
+from tests.helpers import seed_all
+from tests.helpers.testers import MetricTester
+from torchmetrics.image.map import MAP
+
+seed_all(42)
+
+Input = namedtuple('Input', ["preds", "target"])
+
+# _input_size = (NUM_BATCHES, BATCH_SIZE, 32, 32)
+# _inputs = [
+#     Input(
+#         preds=torch.randint(n_cls_pred, _input_size, dtype=torch.float),
+#         target=torch.randint(n_cls_target, _input_size, dtype=torch.float),
+#     ) for n_cls_pred, n_cls_target in [(10, 10), (5, 10), (10, 5)]
+# ]
+
+
+class TestMapMetric(MetricTester):
+    def generate_predictions_targets(self, batch_size):
+        box1 = [0.0, 0.0, 1.0, 1.0, 0.8]  # TP_class0
+        box2 = [1.0, 1.0, 2.0, 2.0, 0.9]  # TP_class0
+        box3 = [2.0, 2.0, 3.0, 3.0, 0.7]  # false class (FN for class_0, FP for class_1?)
+        box4 = [3.0, 3.0, 4.0, 4.0, 1.0]  # FN (missing box for class_0)
+        box5 = [4.0, 4.0, 5.0, 5.0, 0.6]  # FP (detection - but no GT for class_0)
+        box6 = [5.0, 5.0, 6.0, 6.0, 1.0]  # TP_class_2 --> to check if we get precision one for class_2
+
+        targets = {
+            'boxes': [torch.FloatTensor([box1[0:4],
+                                         box2[0:4],
+                                         box3[0:4],
+                                         box4[0:4],
+                                         box6[0:4]])] * batch_size,
+            'labels': [torch.LongTensor([0, 0, 1, 0, 2])] * batch_size
+        }
+        predictions = []
+        for i in range(batch_size):
+            predictions.append(((torch.tensor([box1, box2, box3, box5, box6]), torch.tensor([0, 0, 0, 0, 2]))))
+        # predictions = [(torch.tensor([box1, box2, box3, box5, box6]),
+        #                torch.tensor([0, 0, 0, 0, 2]))*batch_size]
+        # How to calculate expected_values:
+        # sorted by score both classes:
+        # box 2 TP
+        # box 1 TP
+        # box 3 FN
+        # box 5 FN
+
+        # sorted by score class_0:
+        # box 2 TP
+        # box 1 TP
+        # box 5 FN
+
+        # sorted by score class_1:
+        # box 3  missing
+
+        # sorted by score class_2:
+        # box 6 ok --> 1 gt/1 prediction --> 100%
+
+        return predictions, targets
+
+    def test_mAP_average(self):
+        numerical_correction = (201 / 202)  # (1-100/101)/2 --> 101 coming from interpolation)
+        expected_value = (1 / 3 * 1 + 1 / 3 * 0 + 1 / 3 * 2 / 3 * numerical_correction)
+
+        expected_value_class0 = (2 / 3) * numerical_correction
+        expected_value_class1 = (0 / 1)
+        expected_value_class2 = (1 / 1)
+
+        for batch_size in [2, 10]:
+            predictions, targets = self.generate_predictions_targets(batch_size)
+
+            mAP = MAP(num_classes=3)
+            mAP.update(predictions, targets, ['class_0', 'class_1', 'class_2'])
+            mAP.update(predictions, targets, ['class_0', 'class_1', 'class_2'])
+            mAP.update(predictions, targets,
+                       ['class_0', 'class_1', 'class_2'])  # dist_reduce_fx='mean'--> should stay the same value
+            metrics = mAP.compute()
+            map_value = metrics.map_value
+            map_values_class = metrics.map_per_class_value
+            # test if reduction in the Metric is set to mean
+            # self.assertAlmostEqual(map_value.item(), expected_value, delta=1e-05)
+            # self.assertAlmostEqual(map_values_class[0].item(), expected_value_class0, delta=1e-05)
+            # self.assertAlmostEqual(map_values_class[1].item(), expected_value_class1, delta=1e-05)
+            # self.assertAlmostEqual(map_values_class[2].item(), expected_value_class2, delta=1e-05)

--- a/tests/image/test_map.py
+++ b/tests/image/test_map.py
@@ -12,28 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import namedtuple
+import unittest
 
 import torch
 
-from tests.helpers import seed_all
-from tests.helpers.testers import MetricTester
 from torchmetrics.image.map import MAP
 
-seed_all(42)
 
-Input = namedtuple('Input', ["preds", "target"])
-
-# _input_size = (NUM_BATCHES, BATCH_SIZE, 32, 32)
-# _inputs = [
-#     Input(
-#         preds=torch.randint(n_cls_pred, _input_size, dtype=torch.float),
-#         target=torch.randint(n_cls_target, _input_size, dtype=torch.float),
-#     ) for n_cls_pred, n_cls_target in [(10, 10), (5, 10), (10, 5)]
-# ]
-
-
-class TestMapMetric(MetricTester):
+class TestMapMetric(unittest.TestCase):
     def generate_predictions_targets(self, batch_size):
         box1 = [0.0, 0.0, 1.0, 1.0, 0.8]  # TP_class0
         box2 = [1.0, 1.0, 2.0, 2.0, 0.9]  # TP_class0
@@ -42,19 +28,8 @@ class TestMapMetric(MetricTester):
         box5 = [4.0, 4.0, 5.0, 5.0, 0.6]  # FP (detection - but no GT for class_0)
         box6 = [5.0, 5.0, 6.0, 6.0, 1.0]  # TP_class_2 --> to check if we get precision one for class_2
 
-        targets = {
-            'boxes': [torch.FloatTensor([box1[0:4],
-                                         box2[0:4],
-                                         box3[0:4],
-                                         box4[0:4],
-                                         box6[0:4]])] * batch_size,
-            'labels': [torch.LongTensor([0, 0, 1, 0, 2])] * batch_size
-        }
-        predictions = []
-        for i in range(batch_size):
-            predictions.append(((torch.tensor([box1, box2, box3, box5, box6]), torch.tensor([0, 0, 0, 0, 2]))))
-        # predictions = [(torch.tensor([box1, box2, box3, box5, box6]),
-        #                torch.tensor([0, 0, 0, 0, 2]))*batch_size]
+        targets = [torch.tensor([[box1[0:4], box2[0:4], box3[0:4], box4[0:4], box6[0:4]]] * batch_size), torch.tensor([[0, 0, 1, 0, 2]] * batch_size)]
+        predictions = [torch.tensor([[box1, box2, box3, box5, box6]] * batch_size), torch.tensor([[0, 0, 0, 0, 2]] * batch_size)]
         # How to calculate expected_values:
         # sorted by score both classes:
         # box 2 TP
@@ -84,18 +59,18 @@ class TestMapMetric(MetricTester):
         expected_value_class2 = (1 / 1)
 
         for batch_size in [2, 10]:
-            predictions, targets = self.generate_predictions_targets(batch_size)
+            predictions, targets = self.generate_predictions_targets(batch_size=batch_size)
 
             mAP = MAP(num_classes=3)
-            mAP.update(predictions, targets, ['class_0', 'class_1', 'class_2'])
-            mAP.update(predictions, targets, ['class_0', 'class_1', 'class_2'])
-            mAP.update(predictions, targets,
-                       ['class_0', 'class_1', 'class_2'])  # dist_reduce_fx='mean'--> should stay the same value
+            mAP.update(predictions, targets)
+            mAP.update(predictions, targets)
+            mAP.update(predictions, targets)  # dist_reduce_fx='mean' -> should stay the same value
             metrics = mAP.compute()
             map_value = metrics.map_value
             map_values_class = metrics.map_per_class_value
+
             # test if reduction in the Metric is set to mean
-            # self.assertAlmostEqual(map_value.item(), expected_value, delta=1e-05)
-            # self.assertAlmostEqual(map_values_class[0].item(), expected_value_class0, delta=1e-05)
-            # self.assertAlmostEqual(map_values_class[1].item(), expected_value_class1, delta=1e-05)
-            # self.assertAlmostEqual(map_values_class[2].item(), expected_value_class2, delta=1e-05)
+            self.assertAlmostEqual(map_value.item(), expected_value, delta=1e-05)
+            self.assertAlmostEqual(map_values_class[0].item(), expected_value_class0, delta=1e-05)
+            self.assertAlmostEqual(map_values_class[1].item(), expected_value_class1, delta=1e-05)
+            self.assertAlmostEqual(map_values_class[2].item(), expected_value_class2, delta=1e-05)

--- a/torchmetrics/image/map.py
+++ b/torchmetrics/image/map.py
@@ -1,0 +1,170 @@
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import sys
+from dataclasses import dataclass
+
+from typing import Any, Optional, List
+
+import torch
+from torch import Tensor
+from pycocotools.coco import COCO
+from pycocotools.cocoeval import COCOeval
+
+from torchmetrics.metric import Metric
+
+
+@dataclass
+class MAPMetricResults():
+    map_value: Tensor
+    mar_value: Tensor
+    map_per_class_value: List[Tensor]
+    mar_per_class_value: List[Tensor]
+
+
+class hide_prints:
+    def __enter__(self):
+        self._original_stdout = sys.stdout
+        sys.stdout = open(os.devnull, 'w')
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        sys.stdout.close()
+        sys.stdout = self._original_stdout
+
+
+class MAP(Metric):
+    def __init__(
+            self,
+            num_classes: int = 0,
+            compute_on_step: bool = True,
+            dist_sync_on_step: bool = False,
+            process_group: Optional[Any] = None,
+    ) -> None:
+        super().__init__(
+            compute_on_step=compute_on_step,
+            dist_sync_on_step=dist_sync_on_step,
+            process_group=process_group,
+        )
+
+        super().__init__(dist_sync_on_step=dist_sync_on_step)
+        self.add_state('average_precision', default=torch.tensor(data=[], dtype=torch.float), dist_reduce_fx='mean')
+        self.add_state('average_recall', default=torch.tensor(data=[], dtype=torch.float), dist_reduce_fx='mean')
+        self.num_classes = num_classes
+
+        for class_id in range(num_classes):
+            self.add_state(f'ap_{class_id}', default=torch.tensor(data=[], dtype=torch.float),
+                           dist_reduce_fx='mean')
+            self.add_state(f'ar_{class_id}', default=torch.tensor(data=[], dtype=torch.float),
+                           dist_reduce_fx='mean')
+
+    def update(self, preds, target, class_names):
+        coco_target = COCO()
+        coco_target.dataset = get_coco_target(target=target, class_names=class_names)
+
+        coco_preds = COCO()
+        coco_preds.dataset = get_coco_preds(preds=preds, coco_target=coco_target)
+
+        with hide_prints():
+            coco_target.createIndex()
+            coco_preds.createIndex()
+            coco_eval = COCOeval(coco_target, coco_preds, 'bbox')
+            coco_eval.evaluate()
+            coco_eval.accumulate()
+            coco_eval.summarize()
+            stats = coco_eval.stats
+
+        self.average_precision = torch.cat(
+            (self.average_precision,
+             torch.tensor([stats[0]], dtype=torch.float, device=self.average_precision.device)))
+
+        self.average_recall = torch.cat(
+            (self.average_recall, torch.tensor([stats[8]], dtype=torch.float, device=self.average_recall.device)))
+
+        for class_id in range(self.num_classes):
+            coco_eval.params.catIds = [class_id]
+            with hide_prints():
+                coco_eval.evaluate()
+                coco_eval.accumulate()
+                coco_eval.summarize()
+                stats = coco_eval.stats
+
+            current_value = getattr(self, f'ap_{class_id}')
+            class_map_value = torch.cat(
+                (current_value, torch.tensor([stats[0]], dtype=torch.float, device=current_value.device)))
+            setattr(self, f'ap_{class_id}', class_map_value)
+
+            current_value = getattr(self, f'ar_{class_id}')
+            class_map_value = torch.cat(
+                (current_value, torch.tensor([stats[8]], dtype=torch.float, device=current_value.device)))
+            setattr(self, f'ar_{class_id}', class_map_value)
+
+    def compute(self):
+        map_per_class_value = [torch.mean(getattr(self, f'ap_{class_id}')) for class_id in
+                               range(self.num_classes)]
+        mar_per_class_value = [torch.mean(getattr(self, f'ar_{class_id}')) for class_id in
+                               range(self.num_classes)]
+        metrics = MAPMetricResults(map_value=torch.mean(self.average_precision),
+                                   mar_value=torch.mean(self.average_recall),
+                                   map_per_class_value=map_per_class_value,
+                                   mar_per_class_value=mar_per_class_value)
+        return metrics
+
+
+def get_coco_target(target, class_names):
+    image_list = []
+    annotation_list = []
+    annotation_id = 1
+
+    for i, (boxes, labels) in enumerate(zip(target['boxes'], target['labels'])):
+        boxes = boxes.cpu().tolist()
+        labels = labels.cpu().tolist()
+        image_list.append({'id': i})
+        for box, label in zip(boxes, labels):
+            box = box
+            annotation_list.append({
+                'id': annotation_id,
+                'image_id': i,
+                'bbox': box,
+                'category_id': label,
+                'area': box[2] * box[3],
+                'iscrowd': 0
+            })
+            annotation_id += 1
+    classes_list = [{'id': i, 'name': val} for i, val in enumerate(class_names)]
+    return {'images': image_list, 'annotations': annotation_list, 'categories': classes_list}
+
+
+def get_coco_preds(preds, coco_target):
+    image_list = [img for img in coco_target.dataset['images']]
+    annotation_list = []
+    annotation_id = 1
+    for i, (boxes, labels) in enumerate(preds):
+        boxes_scores = boxes.cpu().tolist()
+        boxes = [box[:4] for box in boxes_scores]
+        scores = [box[-1] for box in boxes_scores]
+        labels = labels.cpu().tolist()
+        for box, label, score in zip(boxes, labels, scores):
+            box = box
+            annotation_list.append({
+                'id': annotation_id,
+                'image_id': i,
+                'category_id': label,
+                'bbox': box,
+                'score': score,
+                'area': box[2] * box[3],
+                'iscrowd': 0
+            })
+            annotation_id += 1
+
+    return {'images': image_list, 'annotations': annotation_list, 'categories': coco_target.dataset['categories']}


### PR DESCRIPTION
# Mean Average Precision (mAP) for object detection

New metric for object detection.


## What does this PR do?

This PR introduces the commonly used mean average precision metric for object detection.
As there are multiple different implementations, and even different calculations, the new metric wraps the `pycocotools` evaluation, which is used as a standard for several academic and open-source projects for evaluation.


This metric is actively discussed in issue [https://github.com/PyTorchLightning/metrics/issues/53](https://github.com/PyTorchLightning/metrics/issues/53)

## Note

This is my first contribution to the PyTorchLightning project. Please review the code carefully and give me hints on how to improve and match your guidelines.
