### PR TITLE
Fixed tensor copy to remove UserWarning

### DIFF
--- a/torchmetrics/functional/classification/precision_recall_curve.py
+++ b/torchmetrics/functional/classification/precision_recall_curve.py
@@ -153,7 +153,7 @@ def _precision_recall_curve_compute_single_class(
 
     recall = torch.cat([reversed(recall[sl]), torch.zeros(1, dtype=recall.dtype, device=recall.device)])
 
-    thresholds = reversed(thresholds[sl]).detach().clone()
+    thresholds = reversed(thresholds[sl]).detach().clone()  # type: ignore
 
     return precision, recall, thresholds
 

--- a/torchmetrics/functional/classification/precision_recall_curve.py
+++ b/torchmetrics/functional/classification/precision_recall_curve.py
@@ -153,7 +153,7 @@ def _precision_recall_curve_compute_single_class(
 
     recall = torch.cat([reversed(recall[sl]), torch.zeros(1, dtype=recall.dtype, device=recall.device)])
 
-    thresholds = tensor(reversed(thresholds[sl]))
+    thresholds = reversed(thresholds[sl]).detach().clone()
 
     return precision, recall, thresholds
 


### PR DESCRIPTION
# Before submitting

- [X] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
It changes a line of code in torchmetrics/functional/classification/precision_recall_curve.py to remove a UserWarning that was being thrown.

Fixes #475

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
