### PR TITLE
fixes metric hashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed bug where compositional metrics where unable to sync because of type mismatch ([#454](https://github.com/PyTorchLightning/metrics/pull/454))
 
+
+- Fixed metric hashing ([#478](https://github.com/PyTorchLightning/metrics/pull/478))
+
+
 ## [0.5.0] - 2021-08-09
 
 ### Added

--- a/tests/bases/test_hashing.py
+++ b/tests/bases/test_hashing.py
@@ -1,0 +1,20 @@
+from tests.helpers.testers import DummyMetric, DummyNonTensorMetric
+import pytest
+
+pytest.mark.parametrize(
+    "metric_cls",
+    [
+        (DummyMetric,),
+        (DummyNonTensorMetric,),
+    ],
+)
+def test_metric_hashing(metric_cls):
+    """
+    Tests that hases are different. 
+    See the Metric's hash function for details on why this is required.
+    """
+    instance_1 = metric_cls()
+    instance_2 = metric_cls()
+
+    assert hash(instance_1) != hash(instance_2)
+    assert id(instance_1) != id(instance_2)

--- a/tests/bases/test_hashing.py
+++ b/tests/bases/test_hashing.py
@@ -2,6 +2,7 @@ import pytest
 
 from tests.helpers.testers import DummyListMetric, DummyMetric
 
+
 @pytest.mark.parametrize(
     "metric_cls",
     [

--- a/tests/bases/test_hashing.py
+++ b/tests/bases/test_hashing.py
@@ -1,5 +1,6 @@
-from tests.helpers.testers import DummyMetric, DummyNonTensorMetric
 import pytest
+
+from tests.helpers.testers import DummyMetric, DummyNonTensorMetric
 
 pytest.mark.parametrize(
     "metric_cls",
@@ -8,9 +9,11 @@ pytest.mark.parametrize(
         (DummyNonTensorMetric,),
     ],
 )
+
+
 def test_metric_hashing(metric_cls):
-    """
-    Tests that hases are different. 
+    """Tests that hases are different.
+
     See the Metric's hash function for details on why this is required.
     """
     instance_1 = metric_cls()

--- a/tests/bases/test_hashing.py
+++ b/tests/bases/test_hashing.py
@@ -1,12 +1,12 @@
 import pytest
 
-from tests.helpers.testers import DummyMetric, DummyNonTensorMetric
+from tests.helpers.testers import DummyMetric, DummyListMetric
 
 pytest.mark.parametrize(
     "metric_cls",
     [
         (DummyMetric,),
-        (DummyNonTensorMetric,),
+        (DummyListMetric,),
     ],
 )
 

--- a/tests/bases/test_hashing.py
+++ b/tests/bases/test_hashing.py
@@ -6,8 +6,8 @@ from tests.helpers.testers import DummyListMetric, DummyMetric
 @pytest.mark.parametrize(
     "metric_cls",
     [
-        (DummyMetric,),
-        (DummyListMetric,),
+        DummyMetric,
+        DummyListMetric,
     ],
 )
 def test_metric_hashing(metric_cls):

--- a/tests/bases/test_hashing.py
+++ b/tests/bases/test_hashing.py
@@ -2,15 +2,13 @@ import pytest
 
 from tests.helpers.testers import DummyListMetric, DummyMetric
 
-pytest.mark.parametrize(
+@pytest.mark.parametrize(
     "metric_cls",
     [
         (DummyMetric,),
         (DummyListMetric,),
     ],
 )
-
-
 def test_metric_hashing(metric_cls):
     """Tests that hases are different.
 

--- a/tests/bases/test_hashing.py
+++ b/tests/bases/test_hashing.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests.helpers.testers import DummyMetric, DummyListMetric
+from tests.helpers.testers import DummyListMetric, DummyMetric
 
 pytest.mark.parametrize(
     "metric_cls",

--- a/tests/bases/test_metric.py
+++ b/tests/bases/test_metric.py
@@ -160,7 +160,7 @@ def test_hash():
 
     b1 = B()
     b2 = B()
-    assert hash(b1) == hash(b2)
+    assert hash(b1) != hash(b2) # different ids
     assert isinstance(b1.x, list) and len(b1.x) == 0
     b1.x.append(tensor(5))
     assert isinstance(hash(b1), int)  # <- check that nothing crashes

--- a/tests/bases/test_metric.py
+++ b/tests/bases/test_metric.py
@@ -160,7 +160,7 @@ def test_hash():
 
     b1 = B()
     b2 = B()
-    assert hash(b1) != hash(b2) # different ids
+    assert hash(b1) != hash(b2)  # different ids
     assert isinstance(b1.x, list) and len(b1.x) == 0
     b1.x.append(tensor(5))
     assert isinstance(hash(b1), int)  # <- check that nothing crashes

--- a/tests/helpers/testers.py
+++ b/tests/helpers/testers.py
@@ -511,8 +511,6 @@ class DummyMetric(Metric):
         pass
 
 
-
-
 class DummyListMetric(Metric):
     name = "DummyList"
 

--- a/tests/helpers/testers.py
+++ b/tests/helpers/testers.py
@@ -510,6 +510,18 @@ class DummyMetric(Metric):
     def compute(self):
         pass
 
+class DummyNonTensorMetric(Metric):
+    name = 'DummyNonTensor'
+    def __init__(self):
+        super().__init__()
+        self.add_state('x', [], dist_reduce_fx=None)
+
+    def update(self):
+        pass
+
+    def compute(self):
+        pass
+
 
 class DummyListMetric(Metric):
     name = "DummyList"

--- a/tests/helpers/testers.py
+++ b/tests/helpers/testers.py
@@ -511,18 +511,6 @@ class DummyMetric(Metric):
         pass
 
 
-class DummyNonTensorMetric(Metric):
-    name = "DummyNonTensor"
-
-    def __init__(self):
-        super().__init__()
-        self.add_state("x", [], dist_reduce_fx=None)
-
-    def update(self):
-        pass
-
-    def compute(self):
-        pass
 
 
 class DummyListMetric(Metric):

--- a/tests/helpers/testers.py
+++ b/tests/helpers/testers.py
@@ -510,11 +510,13 @@ class DummyMetric(Metric):
     def compute(self):
         pass
 
+
 class DummyNonTensorMetric(Metric):
-    name = 'DummyNonTensor'
+    name = "DummyNonTensor"
+
     def __init__(self):
         super().__init__()
-        self.add_state('x', [], dist_reduce_fx=None)
+        self.add_state("x", [], dist_reduce_fx=None)
 
     def update(self):
         pass

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -502,7 +502,12 @@ class Metric(nn.Module, ABC):
         return filtered_kwargs
 
     def __hash__(self) -> int:
-        hash_vals = [self.__class__.__name__]
+        # we need to add the id here, since PyTorch requires the hash of an module to be unique.
+        # they rely on that for children discovery 
+        # (see https://github.com/pytorch/pytorch/blob/v1.9.0/torch/nn/modules/module.py#L1544)
+        # For metrics that include tensors it is not a problem, 
+        # since their hash is unique based on the memory location but we cannot rely on that for every metric.
+        hash_vals = [self.__class__.__name__, id(self)]
 
         for key in self._defaults:
             val = getattr(self, key)

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -502,8 +502,8 @@ class Metric(nn.Module, ABC):
         return filtered_kwargs
 
     def __hash__(self) -> int:
-        # we need to add the id here, since PyTorch requires the hash of an module to be unique.
-        # they rely on that for children discovery
+        # we need to add the id here, since PyTorch requires a module hash to be unique.
+        # Internally, PyTorch nn.Module relies on that for children discovery
         # (see https://github.com/pytorch/pytorch/blob/v1.9.0/torch/nn/modules/module.py#L1544)
         # For metrics that include tensors it is not a problem,
         # since their hash is unique based on the memory location but we cannot rely on that for every metric.

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -503,9 +503,9 @@ class Metric(nn.Module, ABC):
 
     def __hash__(self) -> int:
         # we need to add the id here, since PyTorch requires the hash of an module to be unique.
-        # they rely on that for children discovery 
+        # they rely on that for children discovery
         # (see https://github.com/pytorch/pytorch/blob/v1.9.0/torch/nn/modules/module.py#L1544)
-        # For metrics that include tensors it is not a problem, 
+        # For metrics that include tensors it is not a problem,
         # since their hash is unique based on the memory location but we cannot rely on that for every metric.
         hash_vals = [self.__class__.__name__, id(self)]
 


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
We need the hashing to be unique. PyTorch relies on that for children discoverability.

before `hash(AUROC()) == hash(AUROC())` evaluated to true when metrics had an empty non-tensor state (like an empty list) causing some attributes to be not appearing in the children.
Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
