### PR TITLE
Implement MultioutputWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `average` argument to `AveragePrecision` metric for reducing multilabel and multiclass problems ([#477](https://github.com/PyTorchLightning/metrics/pull/477))
 
 
+- Added `MultioutputWrapper` ([#510](https://github.com/PyTorchLightning/metrics/pull/510))
+
+
 ### Changed
 
 - `AveragePrecision` will now as default output the `macro` average for multilabel and multiclass problems ([#477](https://github.com/PyTorchLightning/metrics/pull/477))

--- a/docs/source/references/modules.rst
+++ b/docs/source/references/modules.rst
@@ -578,3 +578,9 @@ MetricTracker
 
 .. autoclass:: torchmetrics.MetricTracker
     :noindex:
+
+MultioutputWrapper
+~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: torchmetrics.MultioutputWrapper
+    :noindex:

--- a/tests/wrappers/test_multioutput.py
+++ b/tests/wrappers/test_multioutput.py
@@ -1,0 +1,27 @@
+import torch
+
+from torchmetrics.wrappers.multioutput import MultioutputWrapper
+from torchmetrics.classification import Accuracy
+from torchmetrics.regression import R2Score
+
+
+def test_multioutput_wrapper():
+    # Multiple outputs, same shapes
+    preds1 = torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=torch.float)
+    target1 = torch.tensor([[1, 4], [3, 2], [5, 6]], dtype=torch.float)
+    preds2 = torch.tensor([[7, 8], [9, 10], [11, 12]], dtype=torch.float)
+    target2 = torch.tensor([[7, 8], [9, 10], [11, 12]], dtype=torch.float)
+
+    r2 = MultioutputWrapper(R2Score(), num_outputs=2)
+    r2.update(preds1, target1)
+    r2.update(preds2, target2)
+
+    # R2 score computed using sklearn's r2_score
+    torch.testing.assert_allclose(r2.compute(), [1, 0.8857])
+
+    # Multiple outputs, different shapes
+    acc = MultioutputWrapper(Accuracy(num_classes=3), num_outputs=2)
+    preds = torch.tensor([[[0.1, 0.3], [0.8, 0.3], [0.1, 0.4]], [[0.8, 0.3], [0.1, 0.4], [0.1, 0.3]]])
+    target = torch.tensor([[1, 2], [1, 1]])
+    acc.update(preds, target)
+    torch.testing.assert_allclose(acc.compute(), [0.5, 1.0])

--- a/tests/wrappers/test_multioutput.py
+++ b/tests/wrappers/test_multioutput.py
@@ -8,7 +8,7 @@ from sklearn.metrics import accuracy_score
 from sklearn.metrics import r2_score as sk_r2score
 
 from tests.helpers import seed_all
-from tests.helpers.testers import BATCH_SIZE, MetricTester, NUM_BATCHES, NUM_CLASSES
+from tests.helpers.testers import BATCH_SIZE, NUM_BATCHES, NUM_CLASSES, MetricTester
 from torchmetrics import Metric
 from torchmetrics.classification import Accuracy
 from torchmetrics.regression import R2Score
@@ -73,7 +73,8 @@ num_targets = 2
 Input = namedtuple("Input", ["preds", "target"])
 
 _multi_target_regression_inputs = Input(
-    preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets), target=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
+    preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
+    target=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
 )
 _multi_target_classification_inputs = Input(
     preds=torch.rand(NUM_BATCHES, BATCH_SIZE, NUM_CLASSES, num_targets),

--- a/tests/wrappers/test_multioutput.py
+++ b/tests/wrappers/test_multioutput.py
@@ -54,6 +54,7 @@ class _MultioutputMetric(Metric):
 
     @torch.jit.unused
     def forward(self, *args, **kwargs):
+        """Run forward on the underlying metric."""
         return self.metric(*args, **kwargs)
 
     def reset(self) -> None:

--- a/tests/wrappers/test_multioutput.py
+++ b/tests/wrappers/test_multioutput.py
@@ -1,48 +1,132 @@
+from collections import namedtuple
 from functools import partial
+from typing import Any, Callable, Optional
 
 import pytest
 import torch
 from sklearn.metrics import accuracy_score
+from sklearn.metrics import r2_score as sk_r2score
 
+from tests.helpers import seed_all
+from tests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from torchmetrics import Metric
 from torchmetrics.classification import Accuracy
 from torchmetrics.regression import R2Score
+from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_1_6
 from torchmetrics.wrappers.multioutput import MultioutputWrapper
+
+seed_all(42)
 
 
 def _multioutput_sk_accuracy(preds, target, num_outputs):
     accs = []
+    print("sk:", preds[:4], target[:4])
     for i in range(num_outputs):
         accs.append(accuracy_score(torch.argmax(preds[:, :, i], dim=1), target[:, i]))
     return accs
 
 
+class _MultioutputMetric(Metric):
+    """Multi-output version of the R2 score class for testing."""
+
+    def __init__(
+        self,
+        base_metric_class,
+        num_outputs: int = 1,
+        compute_on_step: bool = True,
+        dist_sync_on_step: bool = False,
+        process_group: Any = None,
+        dist_sync_fn: Optional[Callable] = None,
+        **base_metric_kwargs,
+    ) -> None:
+        super().__init__(
+            compute_on_step=compute_on_step,
+            dist_sync_on_step=dist_sync_on_step,
+            process_group=process_group,
+            dist_sync_fn=dist_sync_fn,
+        )
+        self.metric = MultioutputWrapper(
+            base_metric_class(**base_metric_kwargs),
+            num_outputs=num_outputs,
+            compute_on_step=compute_on_step,
+            dist_sync_on_step=dist_sync_on_step,
+            dist_sync_fn=dist_sync_fn,
+        )
+
+    def update(self, preds: torch.Tensor, target: torch.Tensor) -> None:
+        """Update the each pair of outputs and predictions."""
+        return self.metric.update(preds, target)
+
+    def compute(self) -> torch.Tensor:
+        """Compute the R2 score between each pair of outputs and predictions."""
+        return self.metric.compute()
+
+    @torch.jit.unused
+    def forward(self, *args, **kwargs):
+        return self.metric(*args, **kwargs)
+
+    def reset(self) -> None:
+        """Reset the underlying metric state."""
+        self.metric.reset()
+
+
+
+num_classes = 3
+num_targets = 2
+
+Input = namedtuple("Input", ["preds", "target"])
+
+_multi_target_regression_inputs = Input(
+    preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
+    target=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
+)
+_multi_target_classification_inputs = Input(
+    preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_classes, num_targets),
+    target=torch.randint(num_classes, (NUM_BATCHES, BATCH_SIZE, num_targets)),
+)
+
+
+def _multi_target_sk_r2score(preds, target, adjusted=0, multioutput="raw_values"):
+    sk_preds = preds.view(-1, num_targets).numpy()
+    sk_target = target.view(-1, num_targets).numpy()
+    r2_score = sk_r2score(sk_target, sk_preds, multioutput=multioutput)
+    if adjusted != 0:
+        r2_score = 1 - (1 - r2_score) * (sk_preds.shape[0] - 1) / (sk_preds.shape[0] - adjusted - 1)
+    return r2_score
+
 @pytest.mark.parametrize(
-    "metric, compare_metric, pred_generator, target_generator, num_rounds",
+    "base_metric_class, compare_metric, preds, target, num_outputs, metric_kwargs",
     [
         (
-            MultioutputWrapper(R2Score(), num_outputs=2),
-            R2Score(num_outputs=2, multioutput="raw_values"),
-            partial(torch.randn, 10, 2),
-            partial(torch.randn, 10, 2),
-            2,
+            R2Score,
+            _multi_target_sk_r2score,
+            _multi_target_regression_inputs.preds,
+            _multi_target_regression_inputs.target,
+            num_targets,
+            {},
         ),
         (
-            MultioutputWrapper(Accuracy(num_classes=3), num_outputs=2),
+            Accuracy,
             partial(_multioutput_sk_accuracy, num_outputs=2),
-            partial(torch.rand, 10, 3, 2),
-            partial(torch.randint, 3, (10, 2)),
-            2,
+            _multi_target_classification_inputs.preds,
+            _multi_target_classification_inputs.target,
+            num_targets,
+            dict(num_classes=num_classes),
         ),
     ],
 )
-def test_multioutput_wrapper(metric, compare_metric, pred_generator, target_generator, num_rounds):
-    """Test that the multioutput wrapper properly slices and computes outputs along the output dimension for both
-    classification and regression metrics."""
-    preds, targets = [], []
-    for _ in range(num_rounds):
-        preds.append(pred_generator())
-        targets.append(target_generator())
-        print(preds[-1].shape, targets[-1].shape)
-        metric.update(preds[-1], targets[-1])
-    expected_metric_val = compare_metric(torch.cat(preds), torch.cat(targets))
-    torch.testing.assert_allclose(metric.compute(), expected_metric_val)
+class TestMultioutputWrapper(MetricTester):
+    @pytest.mark.parametrize("ddp", [True, False])
+    @pytest.mark.parametrize("dist_sync_on_step", [True, False])
+    def test_multioutput_wrapper(self, base_metric_class, compare_metric, preds, target, num_outputs, metric_kwargs, ddp, dist_sync_on_step):
+        """Test that the multioutput wrapper properly slices and computes outputs along the output dimension for both
+        classification and regression metrics."""
+        self.run_class_metric_test(
+            ddp,
+            preds,
+            target,
+            _MultioutputMetric,
+            compare_metric,
+            dist_sync_on_step,
+            metric_args=dict(num_outputs=num_outputs, base_metric_class=base_metric_class, **metric_kwargs),
+        )

--- a/tests/wrappers/test_multioutput.py
+++ b/tests/wrappers/test_multioutput.py
@@ -18,7 +18,7 @@ seed_all(42)
 
 
 class _MultioutputMetric(Metric):
-    """Multi-output version of the R2 score class for testing."""
+    """Test class that allows passing base metric as a class rather than its instantiation to the wrapper."""
 
     def __init__(
         self,
@@ -73,8 +73,7 @@ num_targets = 2
 Input = namedtuple("Input", ["preds", "target"])
 
 _multi_target_regression_inputs = Input(
-    preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
-    target=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
+    preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets), target=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
 )
 _multi_target_classification_inputs = Input(
     preds=torch.rand(NUM_BATCHES, BATCH_SIZE, NUM_CLASSES, num_targets),

--- a/tests/wrappers/test_multioutput.py
+++ b/tests/wrappers/test_multioutput.py
@@ -12,7 +12,6 @@ from tests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
 from torchmetrics import Metric
 from torchmetrics.classification import Accuracy
 from torchmetrics.regression import R2Score
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_1_6
 from torchmetrics.wrappers.multioutput import MultioutputWrapper
 
 seed_all(42)

--- a/tests/wrappers/test_multioutput.py
+++ b/tests/wrappers/test_multioutput.py
@@ -68,7 +68,8 @@ num_targets = 2
 Input = namedtuple("Input", ["preds", "target"])
 
 _multi_target_regression_inputs = Input(
-    preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets), target=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
+    preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
+    target=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
 )
 _multi_target_classification_inputs = Input(
     preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_classes, num_targets),
@@ -117,6 +118,7 @@ def _multi_target_sk_accuracy(preds, target, num_outputs):
 )
 class TestMultioutputWrapper(MetricTester):
     """Test the MultioutputWrapper class with regression and classification inner metrics."""
+
     @pytest.mark.parametrize("ddp", [True, False])
     @pytest.mark.parametrize("dist_sync_on_step", [True, False])
     def test_multioutput_wrapper(

--- a/tests/wrappers/test_multioutput.py
+++ b/tests/wrappers/test_multioutput.py
@@ -18,14 +18,6 @@ from torchmetrics.wrappers.multioutput import MultioutputWrapper
 seed_all(42)
 
 
-def _multioutput_sk_accuracy(preds, target, num_outputs):
-    accs = []
-    print("sk:", preds[:4], target[:4])
-    for i in range(num_outputs):
-        accs.append(accuracy_score(torch.argmax(preds[:, :, i], dim=1), target[:, i]))
-    return accs
-
-
 class _MultioutputMetric(Metric):
     """Multi-output version of the R2 score class for testing."""
 
@@ -76,8 +68,7 @@ num_targets = 2
 Input = namedtuple("Input", ["preds", "target"])
 
 _multi_target_regression_inputs = Input(
-    preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
-    target=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
+    preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets), target=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
 )
 _multi_target_classification_inputs = Input(
     preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_classes, num_targets),
@@ -86,6 +77,7 @@ _multi_target_classification_inputs = Input(
 
 
 def _multi_target_sk_r2score(preds, target, adjusted=0, multioutput="raw_values"):
+    """Compute R2 score over multiple outputs."""
     sk_preds = preds.view(-1, num_targets).numpy()
     sk_target = target.view(-1, num_targets).numpy()
     r2_score = sk_r2score(sk_target, sk_preds, multioutput=multioutput)
@@ -94,6 +86,17 @@ def _multi_target_sk_r2score(preds, target, adjusted=0, multioutput="raw_values"
     return r2_score
 
 
+<<<<<<< HEAD
+=======
+def _multi_target_sk_accuracy(preds, target, num_outputs):
+    """Compute accuracy over multiple outputs."""
+    accs = []
+    for i in range(num_outputs):
+        accs.append(accuracy_score(torch.argmax(preds[:, :, i], dim=1), target[:, i]))
+    return accs
+
+
+>>>>>>> Fix DeepSource flagged issues
 @pytest.mark.parametrize(
     "base_metric_class, compare_metric, preds, target, num_outputs, metric_kwargs",
     [
@@ -107,7 +110,7 @@ def _multi_target_sk_r2score(preds, target, adjusted=0, multioutput="raw_values"
         ),
         (
             Accuracy,
-            partial(_multioutput_sk_accuracy, num_outputs=2),
+            partial(_multi_target_sk_accuracy, num_outputs=2),
             _multi_target_classification_inputs.preds,
             _multi_target_classification_inputs.target,
             num_targets,
@@ -116,6 +119,7 @@ def _multi_target_sk_r2score(preds, target, adjusted=0, multioutput="raw_values"
     ],
 )
 class TestMultioutputWrapper(MetricTester):
+    """Test the MultioutputWrapper class with regression and classification inner metrics."""
     @pytest.mark.parametrize("ddp", [True, False])
     @pytest.mark.parametrize("dist_sync_on_step", [True, False])
     def test_multioutput_wrapper(

--- a/tests/wrappers/test_multioutput.py
+++ b/tests/wrappers/test_multioutput.py
@@ -1,8 +1,8 @@
 from functools import partial
 
 import pytest
-from sklearn.metrics import accuracy_score
 import torch
+from sklearn.metrics import accuracy_score
 
 from torchmetrics.classification import Accuracy
 from torchmetrics.regression import R2Score
@@ -14,7 +14,6 @@ def _multioutput_sk_accuracy(preds, target, num_outputs):
     for i in range(num_outputs):
         accs.append(accuracy_score(torch.argmax(preds[:, :, i], dim=1), target[:, i]))
     return accs
-
 
 
 @pytest.mark.parametrize(
@@ -33,7 +32,7 @@ def _multioutput_sk_accuracy(preds, target, num_outputs):
             partial(torch.rand, 10, 3, 2),
             partial(torch.randint, 3, (10, 2)),
             2,
-        )
+        ),
     ],
 )
 def test_multioutput_wrapper(metric, compare_metric, pred_generator, target_generator, num_rounds):

--- a/tests/wrappers/test_multioutput.py
+++ b/tests/wrappers/test_multioutput.py
@@ -74,7 +74,8 @@ num_targets = 2
 Input = namedtuple("Input", ["preds", "target"])
 
 _multi_target_regression_inputs = Input(
-    preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets), target=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
+    preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
+    target=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
 )
 _multi_target_classification_inputs = Input(
     preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_classes, num_targets),

--- a/tests/wrappers/test_multioutput.py
+++ b/tests/wrappers/test_multioutput.py
@@ -8,7 +8,7 @@ from sklearn.metrics import accuracy_score
 from sklearn.metrics import r2_score as sk_r2score
 
 from tests.helpers import seed_all
-from tests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from tests.helpers.testers import BATCH_SIZE, MetricTester, NUM_BATCHES, NUM_CLASSES
 from torchmetrics import Metric
 from torchmetrics.classification import Accuracy
 from torchmetrics.regression import R2Score
@@ -68,7 +68,6 @@ class _MultioutputMetric(Metric):
         self.metric.reset()
 
 
-num_classes = 3
 num_targets = 2
 
 Input = namedtuple("Input", ["preds", "target"])
@@ -78,8 +77,8 @@ _multi_target_regression_inputs = Input(
     target=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
 )
 _multi_target_classification_inputs = Input(
-    preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_classes, num_targets),
-    target=torch.randint(num_classes, (NUM_BATCHES, BATCH_SIZE, num_targets)),
+    preds=torch.rand(NUM_BATCHES, BATCH_SIZE, NUM_CLASSES, num_targets),
+    target=torch.randint(NUM_CLASSES, (NUM_BATCHES, BATCH_SIZE, num_targets)),
 )
 
 
@@ -118,7 +117,7 @@ def _multi_target_sk_accuracy(preds, target, num_outputs):
             _multi_target_classification_inputs.preds,
             _multi_target_classification_inputs.target,
             num_targets,
-            dict(num_classes=num_classes),
+            dict(num_classes=NUM_CLASSES),
         ),
     ],
 )

--- a/tests/wrappers/test_multioutput.py
+++ b/tests/wrappers/test_multioutput.py
@@ -86,8 +86,6 @@ def _multi_target_sk_r2score(preds, target, adjusted=0, multioutput="raw_values"
     return r2_score
 
 
-<<<<<<< HEAD
-=======
 def _multi_target_sk_accuracy(preds, target, num_outputs):
     """Compute accuracy over multiple outputs."""
     accs = []
@@ -96,7 +94,6 @@ def _multi_target_sk_accuracy(preds, target, num_outputs):
     return accs
 
 
->>>>>>> Fix DeepSource flagged issues
 @pytest.mark.parametrize(
     "base_metric_class, compare_metric, preds, target, num_outputs, metric_kwargs",
     [

--- a/tests/wrappers/test_multioutput.py
+++ b/tests/wrappers/test_multioutput.py
@@ -70,7 +70,6 @@ class _MultioutputMetric(Metric):
         self.metric.reset()
 
 
-
 num_classes = 3
 num_targets = 2
 
@@ -93,6 +92,7 @@ def _multi_target_sk_r2score(preds, target, adjusted=0, multioutput="raw_values"
     if adjusted != 0:
         r2_score = 1 - (1 - r2_score) * (sk_preds.shape[0] - 1) / (sk_preds.shape[0] - adjusted - 1)
     return r2_score
+
 
 @pytest.mark.parametrize(
     "base_metric_class, compare_metric, preds, target, num_outputs, metric_kwargs",
@@ -118,9 +118,11 @@ def _multi_target_sk_r2score(preds, target, adjusted=0, multioutput="raw_values"
 class TestMultioutputWrapper(MetricTester):
     @pytest.mark.parametrize("ddp", [True, False])
     @pytest.mark.parametrize("dist_sync_on_step", [True, False])
-    def test_multioutput_wrapper(self, base_metric_class, compare_metric, preds, target, num_outputs, metric_kwargs, ddp, dist_sync_on_step):
-        """Test that the multioutput wrapper properly slices and computes outputs along the output dimension for both
-        classification and regression metrics."""
+    def test_multioutput_wrapper(
+        self, base_metric_class, compare_metric, preds, target, num_outputs, metric_kwargs, ddp, dist_sync_on_step
+    ):
+        """Test that the multioutput wrapper properly slices and computes outputs along the output dimension for
+        both classification and regression metrics."""
         self.run_class_metric_test(
             ddp,
             preds,

--- a/tests/wrappers/test_multioutput.py
+++ b/tests/wrappers/test_multioutput.py
@@ -42,7 +42,8 @@ class _MultioutputMetric(Metric):
                 dist_sync_on_step=dist_sync_on_step,
                 process_group=process_group,
                 dist_sync_fn=dist_sync_fn,
-                **base_metric_kwargs),
+                **base_metric_kwargs,
+            ),
             num_outputs=num_outputs,
             compute_on_step=compute_on_step,
             dist_sync_on_step=dist_sync_on_step,
@@ -73,8 +74,7 @@ num_targets = 2
 Input = namedtuple("Input", ["preds", "target"])
 
 _multi_target_regression_inputs = Input(
-    preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
-    target=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
+    preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets), target=torch.rand(NUM_BATCHES, BATCH_SIZE, num_targets),
 )
 _multi_target_classification_inputs = Input(
     preds=torch.rand(NUM_BATCHES, BATCH_SIZE, num_classes, num_targets),

--- a/tests/wrappers/test_multioutput.py
+++ b/tests/wrappers/test_multioutput.py
@@ -37,7 +37,12 @@ class _MultioutputMetric(Metric):
             dist_sync_fn=dist_sync_fn,
         )
         self.metric = MultioutputWrapper(
-            base_metric_class(**base_metric_kwargs),
+            base_metric_class(
+                compute_on_step=compute_on_step,
+                dist_sync_on_step=dist_sync_on_step,
+                process_group=process_group,
+                dist_sync_fn=dist_sync_fn,
+                **base_metric_kwargs),
             num_outputs=num_outputs,
             compute_on_step=compute_on_step,
             dist_sync_on_step=dist_sync_on_step,

--- a/tests/wrappers/test_multioutput.py
+++ b/tests/wrappers/test_multioutput.py
@@ -1,8 +1,8 @@
 import torch
 
-from torchmetrics.wrappers.multioutput import MultioutputWrapper
 from torchmetrics.classification import Accuracy
 from torchmetrics.regression import R2Score
+from torchmetrics.wrappers.multioutput import MultioutputWrapper
 
 
 def test_multioutput_wrapper():

--- a/tests/wrappers/test_multioutput.py
+++ b/tests/wrappers/test_multioutput.py
@@ -6,6 +6,8 @@ from torchmetrics.wrappers.multioutput import MultioutputWrapper
 
 
 def test_multioutput_wrapper():
+    """Test that the multioutput wrapper properly slices and computes outputs along the output dimension for both
+    classification and regression metrics."""
     # Multiple outputs, same shapes
     preds1 = torch.tensor([[1, 2], [3, 4], [5, 6]], dtype=torch.float)
     target1 = torch.tensor([[1, 4], [3, 2], [5, 6]], dtype=torch.float)

--- a/torchmetrics/__init__.py
+++ b/torchmetrics/__init__.py
@@ -64,7 +64,7 @@ from torchmetrics.retrieval import (  # noqa: E402
     RetrievalRecall,
 )
 from torchmetrics.text import WER, BERTScore, BLEUScore, ROUGEScore  # noqa: E402
-from torchmetrics.wrappers import BootStrapper, MetricTracker  # noqa: E402
+from torchmetrics.wrappers import BootStrapper, MetricTracker, MultioutputWrapper  # noqa: E402
 
 __all__ = [
     "functional",

--- a/torchmetrics/__init__.py
+++ b/torchmetrics/__init__.py
@@ -103,6 +103,7 @@ __all__ = [
     "Metric",
     "MetricCollection",
     "MetricTracker",
+    "MultioutputWrapper",
     "PearsonCorrcoef",
     "PIT",
     "Precision",

--- a/torchmetrics/wrappers/__init__.py
+++ b/torchmetrics/wrappers/__init__.py
@@ -13,3 +13,4 @@
 # limitations under the License.
 from torchmetrics.wrappers.bootstrapping import BootStrapper  # noqa: F401
 from torchmetrics.wrappers.tracker import MetricTracker  # noqa: F401
+from torchmetrics.wrappers.multioutput import MultioutputWrapper  # noqa: F401

--- a/torchmetrics/wrappers/__init__.py
+++ b/torchmetrics/wrappers/__init__.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from torchmetrics.wrappers.bootstrapping import BootStrapper  # noqa: F401
-from torchmetrics.wrappers.tracker import MetricTracker  # noqa: F401
 from torchmetrics.wrappers.multioutput import MultioutputWrapper  # noqa: F401
+from torchmetrics.wrappers.tracker import MetricTracker  # noqa: F401

--- a/torchmetrics/wrappers/__init__.py
+++ b/torchmetrics/wrappers/__init__.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from torchmetrics.wrappers.bootstrapping import BootStrapper  # noqa: F401
-from torchmetrics.wrappers.multioutput import MultioutputWrapper  # noqa: F401
 from torchmetrics.wrappers.tracker import MetricTracker  # noqa: F401
+from torchmetrics.wrappers.multioutput import MultioutputWrapper  # noqa: F401

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -8,14 +8,14 @@ from torchmetrics import Metric
 from torchmetrics.utilities import apply_to_collection
 
 
-def _get_nan_indices(*tensors: torch.Tensor, aligned_dim: int = 0) -> torch.Tensor:
-    """Get indices of rows along `aligned_dim` which have NaN values."""
+def _get_nan_indices(*tensors: torch.Tensor) -> torch.Tensor:
+    """Get indices of rows along dim 0 which have NaN values."""
     if len(tensors) == 0:
         raise ValueError("Must pass at least one tensor as argument")
     sentinel = tensors[0]
     nan_idxs = torch.zeros(len(sentinel), dtype=torch.bool)
     for tensor in tensors:
-        permuted_tensor = tensor.movedim(aligned_dim, 0).flatten(start_dim=1)
+        permuted_tensor = tensor.flatten(start_dim=1)
         nan_idxs |= torch.any(permuted_tensor.isnan(), dim=1)
     return nan_idxs
 

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -13,7 +13,7 @@ def _get_nan_indices(*tensors: torch.Tensor) -> torch.Tensor:
     if len(tensors) == 0:
         raise ValueError("Must pass at least one tensor as argument")
     sentinel = tensors[0]
-    nan_idxs = torch.zeros(len(sentinel), dtype=torch.bool)
+    nan_idxs = torch.zeros(len(sentinel), dtype=torch.bool, device=sentinel.device)
     for tensor in tensors:
         permuted_tensor = tensor.flatten(start_dim=1)
         nan_idxs |= torch.any(torch.isnan(permuted_tensor), dim=1)

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Optional
 
 import torch
 from torch import nn
+
 from torchmetrics import Metric
 from torchmetrics.utilities import apply_to_collection
 
@@ -22,8 +23,7 @@ def _get_nan_indices(*tensors: torch.Tensor, aligned_dim: int = 0) -> torch.Tens
 
 
 class MultioutputWrapper(Metric):
-    """
-    Wrap a base metric to enable it to support multiple outputs.
+    """Wrap a base metric to enable it to support multiple outputs.
 
     Several torchmetrics metrics, such as :class:`torchmetrics.regression.spearman.SpearmanCorrcoef` lack support for
     multioutput mode. This class wraps such metrics to support computing one metric per output.

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -66,7 +66,7 @@ class MultioutputWrapper(Metric):
 
     Example:
 
-         Mimic R2Score in `multioutput`, `raw_values` mode:
+         >>> # Mimic R2Score in `multioutput`, `raw_values` mode:
          >>> import torch
          >>> from torchmetrics import MultioutputWrapper, R2Score
          >>> target = torch.tensor([[0.5, 1], [-1, 1], [7, -6]])
@@ -74,8 +74,7 @@ class MultioutputWrapper(Metric):
          >>> r2score = MultioutputWrapper(R2Score(), 2)
          >>> r2score(preds, target)
          [tensor(0.9654), tensor(0.9082)]
-
-        Classification metric where prediction and label tensors have different shapes.
+         >>> # Classification metric where prediction and label tensors have different shapes.
          >>> from torchmetrics import BinnedAveragePrecision
          >>> target = torch.tensor([[1, 2], [2, 0], [1, 2]])
          >>> preds = torch.tensor([

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -152,10 +152,9 @@ class MultioutputWrapper(Metric):
         reshaped_args_kwargs = self._get_args_kwargs_by_output(*args, **kwargs)
         for metric, (selected_args, selected_kwargs) in zip(self.metrics, reshaped_args_kwargs):
             results.append(metric(*selected_args, **selected_kwargs))
-        if results[0] is not None:
-            return results
-        else:
+        if results[0] is None:
             return None
+        return results
 
     @property
     def is_differentiable(self) -> bool:

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -37,32 +37,32 @@ class MultioutputWrapper(Metric):
     (parameter `remove_nans`) on a per-output basis. When `remove_nans` is passed the wrapper will remove all rows
 
     Args:
-        base_metric: Metric,
+        base_metric:
             Metric being wrapped.
-        num_outputs: int
+        num_outputs:
             Expected dimensionality of the output dimension. This parameter is
             used to determine the number of distinct metrics we need to track.
-        output_dim: int = -1
+        output_dim:
             Dimension on which output is expected. Note that while this provides some flexibility, the output dimension
             must be the same for all inputs to update. This applies even for metrics such as `Accuracy` where the labels
             can have a different number of dimensions than the predictions. This can be worked around if the output
             dimension can be set to -1 for both, even if -1 corresponds to different dimensions in different inputs.
-        remove_nans: bool = True
+        remove_nans:
             Whether to remove the intersection of rows containing NaNs from the values passed through to each underlying
             metric. Proper operation requires all tensors passed to update to have dimension `(N, ...)` where N
             represents the length of the batch or dataset being passed in.
-        squeeze_outputs: bool = True
+        squeeze_outputs:
             If true, will squeeze the 1-item dimensions left after `index_select` is applied.
             This is sometimes unnecessary but harmless for metrics such as `R2Score` but useful
             for certain classification metrics that can't handle additional 1-item dimensions.
-        compute_on_step: bool = True
+        compute_on_step:
             Whether to recompute the metric value on each update step.
-        dist_sync_on_step: bool = False
-            Required for distributed training support. See torchmetrics docs for additional details.
-        process_group: Optional[Any]
-            Specify the process group on which synchronization is called. default: None (which selects the entire world)
-        dist_sync_fn: Callable = None,
-            Required for distributed training support. See torchmetrics docs for additional details.
+        dist_sync_on_step:
+            Required for distributed training support.
+        process_group:
+            Specify the process group on which synchronization is called. The default: None (which selects the entire world)
+        dist_sync_fn:
+            Required for distributed training support.
 
     Example:
 

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -29,11 +29,11 @@ class MultioutputWrapper(Metric):
     (2, ...) where ... represents the dimensions the metric returns when not wrapped.
 
     In addition to enabling multioutput support for metrics that lack it, this class also supports, albeit in a crude
-    fashion, dealing with missing labels (or other data). When `remove_nans` is passed, the class will remove the
+    fashion, dealing with missing labels (or other data). When ``remove_nans`` is passed, the class will remove the
     intersection of NaN containing "rows" upon each update for each output. For example, suppose a user uses
     `MultioutputWrapper` to wrap :class:`torchmetrics.regression.r2.R2Score` with 2 outputs, one of which occasionally
-    has missing labels for classes like `R2Score` is that this class supports removing NaN values
-    (parameter `remove_nans`) on a per-output basis. When `remove_nans` is passed the wrapper will remove all rows
+    has missing labels for classes like ``R2Score`` is that this class supports removing NaN values
+    (parameter ``remove_nans``) on a per-output basis. When ``remove_nans`` is passed the wrapper will remove all rows
 
     Args:
         base_metric:

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -16,7 +16,7 @@ def _get_nan_indices(*tensors: torch.Tensor) -> torch.Tensor:
     nan_idxs = torch.zeros(len(sentinel), dtype=torch.bool)
     for tensor in tensors:
         permuted_tensor = tensor.flatten(start_dim=1)
-        nan_idxs |= torch.any(permuted_tensor.isnan(), dim=1)
+        nan_idxs |= torch.any(torch.isnan(permuted_tensor), dim=1)
     return nan_idxs
 
 

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -37,28 +37,27 @@ class MultioutputWrapper(Metric):
     `R2Score` is that this class supports removing NaN values (parameter `remove_nans`) on a per-output basis. When
     `remove_nans` is passed the wrapper will remove all rows
 
-    Parameters
-    ----------
-    base_metric: Metric,
-        Metric being wrapped.
-    num_outputs: int = 1,
-        Expected dimensionality of the output dimension. This parameter is
-        used to determine the number of distinct metrics we need to track.
-    output_dim: int = -1,
-        Dimension on which output is expected. Note that while this provides some flexibility, the output dimension
-        must be the same for all inputs to update. This applies even for metrics such as `Accuracy` where the labels
-        can have a different number of dimensions than the predictions. This can be worked around if the output dimension
-        can be set to -1 for both, even if -1 corresponds to different dimensions in different inputs.
-    remove_nans: bool = True,
-        Whether to remove the intersection of rows containing NaNs from the values passed through to each underlying
-        metric. Proper operation requires all tensors passed to update to have dimension `(N, ...)` where N represents
-        the length of the batch or dataset being passed in.
-    compute_on_step: bool = True,
-        Whether to recompute the metric value on each update step.
-    dist_sync_on_step: bool = False,
-        Required for distributed training support. See torchmetrics docs for additional details.
-    dist_sync_fn: Callable = None,
-        Required for distributed training support. See torchmetrics docs for additional details.
+    Args:
+        base_metric: Metric,
+            Metric being wrapped.
+        num_outputs: int = 1,
+            Expected dimensionality of the output dimension. This parameter is
+            used to determine the number of distinct metrics we need to track.
+        output_dim: int = -1,
+            Dimension on which output is expected. Note that while this provides some flexibility, the output dimension
+            must be the same for all inputs to update. This applies even for metrics such as `Accuracy` where the labels
+            can have a different number of dimensions than the predictions. This can be worked around if the output dimension
+            can be set to -1 for both, even if -1 corresponds to different dimensions in different inputs.
+        remove_nans: bool = True,
+            Whether to remove the intersection of rows containing NaNs from the values passed through to each underlying
+            metric. Proper operation requires all tensors passed to update to have dimension `(N, ...)` where N represents
+            the length of the batch or dataset being passed in.
+        compute_on_step: bool = True,
+            Whether to recompute the metric value on each update step.
+        dist_sync_on_step: bool = False,
+            Required for distributed training support. See torchmetrics docs for additional details.
+        dist_sync_fn: Callable = None,
+            Required for distributed training support. See torchmetrics docs for additional details.
     """
 
     def __init__(

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -25,8 +25,7 @@ class MultioutputWrapper(Metric):
 
     Several torchmetrics metrics, such as :class:`torchmetrics.regression.spearman.SpearmanCorrcoef` lack support for
     multioutput mode. This class wraps such metrics to support computing one metric per output.
-    Unlike specific torchmetric metrics, it doesn't support any
-    aggregation across outputs. This means if you set `num_outputs` to 2, `compute()` will return a Tensor of dimension
+    Unlike specific torchmetric metrics, it doesn't support any aggregation across outputs. This means if you set `num_outputs` to 2, `compute()` will return a Tensor of dimension
     (2, ...) where ... represents the dimensions the metric returns when not wrapped.
 
     In addition to enabling multioutput support for metrics that lack it, this class also supports, albeit in a crude

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -39,26 +39,27 @@ class MultioutputWrapper(Metric):
     Args:
         base_metric: Metric,
             Metric being wrapped.
-        num_outputs: int = 1,
+        num_outputs: int
             Expected dimensionality of the output dimension. This parameter is
             used to determine the number of distinct metrics we need to track.
-        output_dim: int = -1,
+        output_dim: int = -1
             Dimension on which output is expected. Note that while this provides some flexibility, the output dimension
             must be the same for all inputs to update. This applies even for metrics such as `Accuracy` where the labels
             can have a different number of dimensions than the predictions. This can be worked around if the output
             dimension can be set to -1 for both, even if -1 corresponds to different dimensions in different inputs.
-        remove_nans: bool = True,
+        remove_nans: bool = True
             Whether to remove the intersection of rows containing NaNs from the values passed through to each underlying
             metric. Proper operation requires all tensors passed to update to have dimension `(N, ...)` where N
             represents the length of the batch or dataset being passed in.
         squeeze_outputs: bool = True
-            Whether to
-
+            If true, will squeeze the 1-item dimensions left after `index_select` is applied.
+            This is sometimes unnecessary but harmless for metrics such as `R2Score` but useful
+            for certain classification metrics that can't handle additional 1-item dimensions.
         compute_on_step: bool = True
             Whether to recompute the metric value on each update step.
-        dist_sync_on_step: bool = False,
+        dist_sync_on_step: bool = False
             Required for distributed training support. See torchmetrics docs for additional details.
-        process_group:
+        process_group: Optional[Any]
             Specify the process group on which synchronization is called. default: None (which selects the entire world)
         dist_sync_fn: Callable = None,
             Required for distributed training support. See torchmetrics docs for additional details.
@@ -108,6 +109,7 @@ class MultioutputWrapper(Metric):
         self.metrics = nn.ModuleList([deepcopy(base_metric) for _ in range(num_outputs)])
         self.output_dim = output_dim
         self.remove_nans = remove_nans
+        self.squeeze_outputs = squeeze_outputs
 
     def update(self, *args: Any, **kwargs: Any) -> None:
         """Update each underlying metric with the corresponding output."""

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -111,7 +111,9 @@ class MultioutputWrapper(Metric):
         self.remove_nans = remove_nans
         self.squeeze_outputs = squeeze_outputs
 
-    def _get_args_kwargs_by_output(self, *args: torch.Tensor, **kwargs: torch.Tensor) -> List[Tuple[torch.Tensor, torch.Tensor]]:
+    def _get_args_kwargs_by_output(
+        self, *args: torch.Tensor, **kwargs: torch.Tensor
+    ) -> List[Tuple[torch.Tensor, torch.Tensor]]:
         """Get args and kwargs reshaped to be output-specific and (maybe) having NaNs stripped out."""
         args_kwargs_by_output = []
         for i in range(len(self.metrics)):

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -1,0 +1,106 @@
+from copy import deepcopy
+from typing import Any, Callable, List, Optional
+
+import torch
+from torch import nn
+from torchmetrics import Metric
+from torchmetrics.utilities import apply_to_collection
+
+
+def _get_nan_indices(*tensors: torch.Tensor, aligned_dim: int = 0) -> torch.Tensor:
+    if len(tensors) == 0:
+        raise ValueError("Must pass at least one tensor as argument")
+    sentinel = tensors[0]
+    nan_idxs = torch.zeros(len(sentinel), dtype=torch.bool)
+    for tensor in tensors:
+        assert (
+            tensor.shape[aligned_dim] == sentinel.shape[aligned_dim]
+        ), f"{tensor.shape} != {sentinel.shape} (dim: {aligned_dim})"
+        permuted_tensor = tensor.movedim(aligned_dim, 0).flatten(start_dim=1)
+        nan_idxs |= torch.any(permuted_tensor.isnan(), dim=1)
+    return nan_idxs
+
+
+class MultioutputWrapper(Metric):
+    """
+    Wrap a base metric to enable it to support multiple outputs.
+
+    Several torchmetrics metrics, such as `SpearmanCorroef` lack support for multioutput mode. This class wraps such
+    metrics to support computing one metric per output. Unlike specific torchmetric metrics, it doesn't support any
+    aggregation across outputs. This means if you set `num_outputs` to 2, `compute()` will return a Tensor of dimension
+    (2, ...) where ... represents the dimensions the metric returns when not wrapped.
+
+    In addition to enabling multioutput support for metrics that lack it, this class also supports, albeit in a crude
+    fashion, dealing with missing labels (or other data). When `remove_nans` is passed, the class will remove the
+    intersection of NaN containing "rows" upon each update for each output. For example, suppose a user uses
+    `MultioutputWrapper` to wrap `R2Score` with 2 outputs, one of which occasionally has missing labels for classes like
+    `R2Score` is that this class supports removing NaN values (parameter `remove_nans`) on a per-output basis. When
+    `remove_nans` is passed the wrapper will remove all rows
+
+    Parameters
+    ----------
+    base_metric: Metric,
+        Metric being wrapped.
+    num_outputs: int = 1,
+        Expected dimensionality of the output dimension. This parameter is
+        used to determine the number of distinct metrics we need to track.
+    output_dim: int = -1,
+        Dimension on which output is expected. Note that while this provides some flexibility, the output dimension
+        must be the same for all inputs to update. This applies even for metrics such as `Accuracy` where the labels
+        can have a different number of dimensions than the predictions. This can be worked around if the output dimension
+        can be set to -1 for both, even if -1 corresponds to different dimensions in different inputs.
+    remove_nans: bool = True,
+        Whether to remove the intersection of rows containing NaNs from the values passed through to each underlying
+        metric. Proper operation requires all tensors passed to update to have dimension `(N, ...)` where N represents
+        the length of the batch or dataset being passed in.
+    compute_on_step: bool = True,
+        Whether to recompute the metric value on each update step.
+    dist_sync_on_step: bool = False,
+        Required for distributed training support. See torchmetrics docs for additional details.
+    dist_sync_fn: Callable = None,
+        Required for distributed training support. See torchmetrics docs for additional details.
+    """
+
+    def __init__(
+        self,
+        base_metric: Metric,
+        num_outputs: int = 1,
+        output_dim: int = -1,
+        remove_nans: bool = True,
+        compute_on_step: bool = True,
+        dist_sync_on_step: bool = False,
+        dist_sync_fn: Callable = None,
+    ):
+        super().__init__(compute_on_step, dist_sync_on_step, dist_sync_fn)
+        self.metrics = nn.ModuleList([deepcopy(base_metric) for _ in range(num_outputs)])
+        self.output_dim = output_dim
+        self.remove_nans = remove_nans
+
+    def update(self, *args: Any, **kwargs: Any) -> None:
+        """Update each underlying metric with the corresponding output."""
+        for i in range(len(self.metrics)):
+            selected_args = apply_to_collection(
+                args, torch.Tensor, torch.index_select, dim=self.output_dim, index=torch.tensor(i)
+            )
+            selected_kwargs = apply_to_collection(
+                kwargs, torch.Tensor, torch.index_select, dim=self.output_dim, index=torch.tensor(i)
+            )
+            if self.remove_nans:
+                args_kwargs = selected_args + tuple(selected_kwargs.values())
+                nan_idxs = _get_nan_indices(*args_kwargs)
+                selected_args = [arg[~nan_idxs] for arg in selected_args]
+                selected_kwargs = {k: v[~nan_idxs] for k, v in selected_kwargs.items()}
+            self.metrics[i].update(*selected_args, **selected_kwargs)
+
+    def compute(self) -> torch.Tensor:
+        """Compute metrics."""
+        return torch.stack([m.compute() for m in self.metrics], dim=0)
+
+    @property
+    def is_differentiable(self) -> bool:
+        False
+
+    def reset(self):
+        """Reset all underlying metrics."""
+        for metric in self.metrics:
+            metric.reset()

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, Optional
 
 import torch
 from torch import nn
@@ -25,17 +25,18 @@ class MultioutputWrapper(Metric):
     """
     Wrap a base metric to enable it to support multiple outputs.
 
-    Several torchmetrics metrics, such as `SpearmanCorroef` lack support for multioutput mode. This class wraps such
-    metrics to support computing one metric per output. Unlike specific torchmetric metrics, it doesn't support any
+    Several torchmetrics metrics, such as :class:`torchmetrics.regression.spearman.SpearmanCorrcoef` lack support for
+    multioutput mode. This class wraps such metrics to support computing one metric per output.
+    Unlike specific torchmetric metrics, it doesn't support any
     aggregation across outputs. This means if you set `num_outputs` to 2, `compute()` will return a Tensor of dimension
     (2, ...) where ... represents the dimensions the metric returns when not wrapped.
 
     In addition to enabling multioutput support for metrics that lack it, this class also supports, albeit in a crude
     fashion, dealing with missing labels (or other data). When `remove_nans` is passed, the class will remove the
     intersection of NaN containing "rows" upon each update for each output. For example, suppose a user uses
-    `MultioutputWrapper` to wrap `R2Score` with 2 outputs, one of which occasionally has missing labels for classes like
-    `R2Score` is that this class supports removing NaN values (parameter `remove_nans`) on a per-output basis. When
-    `remove_nans` is passed the wrapper will remove all rows
+    `MultioutputWrapper` to wrap :class:`torchmetrics.regression.r2.R2Score` with 2 outputs, one of which occasionally
+    has missing labels for classes like `R2Score` is that this class supports removing NaN values
+    (parameter `remove_nans`) on a per-output basis. When `remove_nans` is passed the wrapper will remove all rows
 
     Args:
         base_metric: Metric,
@@ -46,16 +47,18 @@ class MultioutputWrapper(Metric):
         output_dim: int = -1,
             Dimension on which output is expected. Note that while this provides some flexibility, the output dimension
             must be the same for all inputs to update. This applies even for metrics such as `Accuracy` where the labels
-            can have a different number of dimensions than the predictions. This can be worked around if the output dimension
-            can be set to -1 for both, even if -1 corresponds to different dimensions in different inputs.
+            can have a different number of dimensions than the predictions. This can be worked around if the output
+            dimension can be set to -1 for both, even if -1 corresponds to different dimensions in different inputs.
         remove_nans: bool = True,
             Whether to remove the intersection of rows containing NaNs from the values passed through to each underlying
-            metric. Proper operation requires all tensors passed to update to have dimension `(N, ...)` where N represents
-            the length of the batch or dataset being passed in.
+            metric. Proper operation requires all tensors passed to update to have dimension `(N, ...)` where N
+            represents the length of the batch or dataset being passed in.
         compute_on_step: bool = True,
             Whether to recompute the metric value on each update step.
         dist_sync_on_step: bool = False,
             Required for distributed training support. See torchmetrics docs for additional details.
+        process_group:
+            Specify the process group on which synchronization is called. default: None (which selects the entire world)
         dist_sync_fn: Callable = None,
             Required for distributed training support. See torchmetrics docs for additional details.
     """
@@ -68,9 +71,15 @@ class MultioutputWrapper(Metric):
         remove_nans: bool = True,
         compute_on_step: bool = True,
         dist_sync_on_step: bool = False,
+        process_group: Optional[Any] = None,
         dist_sync_fn: Callable = None,
     ):
-        super().__init__(compute_on_step, dist_sync_on_step, dist_sync_fn)
+        super().__init__(
+            compute_on_step=compute_on_step,
+            dist_sync_on_step=dist_sync_on_step,
+            process_group=process_group,
+            dist_sync_fn=dist_sync_fn,
+        )
         self.metrics = nn.ModuleList([deepcopy(base_metric) for _ in range(num_outputs)])
         self.output_dim = output_dim
         self.remove_nans = remove_nans

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, List, Optional, Tuple
 
 import torch
 from torch import nn
@@ -111,7 +111,7 @@ class MultioutputWrapper(Metric):
         self.remove_nans = remove_nans
         self.squeeze_outputs = squeeze_outputs
 
-    def _get_args_kwargs_by_output(self, *args, **kwargs):
+    def _get_args_kwargs_by_output(self, *args: torch.Tensor, **kwargs: torch.Tensor) -> List[Tuple[torch.Tensor, torch.Tensor]]:
         """Get args and kwargs reshaped to be output-specific and (maybe) having NaNs stripped out."""
         args_kwargs_by_output = []
         for i in range(len(self.metrics)):

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -139,7 +139,7 @@ class MultioutputWrapper(Metric):
     def is_differentiable(self) -> bool:
         return False
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset all underlying metrics."""
         for metric in self.metrics:
             metric.reset()

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -150,7 +150,6 @@ class MultioutputWrapper(Metric):
         if results[0] is not None:
             return results
 
-
     @property
     def is_differentiable(self) -> bool:
         return False

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -25,7 +25,8 @@ class MultioutputWrapper(Metric):
 
     Several torchmetrics metrics, such as :class:`torchmetrics.regression.spearman.SpearmanCorrcoef` lack support for
     multioutput mode. This class wraps such metrics to support computing one metric per output.
-    Unlike specific torchmetric metrics, it doesn't support any aggregation across outputs. This means if you set `num_outputs` to 2, `compute()` will return a Tensor of dimension
+    Unlike specific torchmetric metrics, it doesn't support any aggregation across outputs.
+    This means if you set `num_outputs` to 2, `compute()` will return a Tensor of dimension
     (2, ...) where ... represents the dimensions the metric returns when not wrapped.
 
     In addition to enabling multioutput support for metrics that lack it, this class also supports, albeit in a crude
@@ -59,7 +60,8 @@ class MultioutputWrapper(Metric):
         dist_sync_on_step:
             Required for distributed training support.
         process_group:
-            Specify the process group on which synchronization is called. The default: None (which selects the entire world)
+            Specify the process group on which synchronization is called.
+            The default: None (which selects the entire world)
         dist_sync_fn:
             Required for distributed training support.
 

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -144,11 +144,9 @@ class MultioutputWrapper(Metric):
 
     @torch.jit.unused
     def forward(self, *args: Any, **kwargs: Any) -> Any:
-        """
-        Call underlying forward methods and aggregate the results if they're non-null.
+        """Call underlying forward methods and aggregate the results if they're non-null.
 
-        We override this method to ensure that state variables get copied over on the
-        underlying metrics.
+        We override this method to ensure that state variables get copied over on the underlying metrics.
         """
         results = []
         reshaped_args_kwargs = self._get_args_kwargs_by_output(*args, **kwargs)

--- a/torchmetrics/wrappers/multioutput.py
+++ b/torchmetrics/wrappers/multioutput.py
@@ -85,8 +85,6 @@ class MultioutputWrapper(Metric):
          >>> binned_avg_precision = MultioutputWrapper(BinnedAveragePrecision(3, thresholds=5), 2)
          >>> binned_avg_precision(preds, target)
          [[tensor(-0.), tensor(1.0000), tensor(1.0000)], [tensor(0.3333), tensor(-0.), tensor(0.6667)]]
-
-
     """
 
     def __init__(


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?

Implements the `MultioutputWrapper` feature described in #508. Summarizing, `MultioutputWrapper` takes a base metric and a `num_outputs` param and returns a metric that will compute `shape[output_dim]` many scalars and return them in a list. The idea is to support `multioutput` mode for metrics like `SpearmanCorrcoef` that don't support it natively.
