### PR TITLE
Fix child device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug in `F1` with `average='macro'` and `ignore_index!=None` ([#495](https://github.com/PyTorchLightning/metrics/pull/495))
 
 
+- Fixed bug where `device` property was not properly update when metric was a child of a module ([#542](https://github.com/PyTorchLightning/metrics/pull/542))
+
 ## [0.5.1] - 2021-08-30
 
 ### Added

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,6 +19,7 @@ scikit-image>0.17.1
 # add extra requirements
 -r image.txt
 -r text.txt
+-r integrate.txt
 
 # audio
 pypesq

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,7 +19,6 @@ scikit-image>0.17.1
 # add extra requirements
 -r image.txt
 -r text.txt
--r integrate.txt
 
 # audio
 pypesq

--- a/tests/bases/test_metric.py
+++ b/tests/bases/test_metric.py
@@ -260,7 +260,7 @@ def test_device_and_dtype_transfer(tmpdir):
 
     metric = metric.to(device="cuda")
     assert metric.x.is_cuda
-    assert metric.device == torch.device("cuda")
+    assert metric.device == torch.device("cuda", index=0)
 
     metric.set_dtype(torch.double)
     assert metric.x.dtype == torch.float64
@@ -350,4 +350,3 @@ def test_device_if_child_module(metric_class):
     assert module.device == module.metric.device
     if isinstance(module.metric.x, Tensor):
         assert module.device == module.metric.x.device
-

--- a/tests/bases/test_metric.py
+++ b/tests/bases/test_metric.py
@@ -19,8 +19,7 @@ import numpy as np
 import pytest
 import torch
 from pytorch_lightning import LightningModule
-from torch import nn, tensor
-from torch.functional import Tensor
+from torch import nn, tensor, Tensor
 
 from tests.helpers import _LIGHTNING_GREATER_EQUAL_1_3, seed_all
 from tests.helpers.testers import DummyListMetric, DummyMetric, DummyMetricMultiOutput, DummyMetricSum

--- a/tests/bases/test_metric.py
+++ b/tests/bases/test_metric.py
@@ -19,6 +19,8 @@ import numpy as np
 import pytest
 import torch
 from torch import nn, tensor
+from pytorch_lightning import LightningModule
+from torch.functional import Tensor
 
 from tests.helpers import _LIGHTNING_GREATER_EQUAL_1_3, seed_all
 from tests.helpers.testers import DummyListMetric, DummyMetric, DummyMetricMultiOutput, DummyMetricSum
@@ -326,3 +328,26 @@ def test_forward_and_compute_to_device(metric_class):
     assert metric._computed is not None
     is_cuda = metric._computed[0].is_cuda if isinstance(metric._computed, list) else metric._computed.is_cuda
     assert is_cuda, "computed result was not moved to the correct device"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU.")
+@pytest.mark.parametrize("metric_class", [DummyMetricSum, DummyMetricMultiOutput])
+def test_device_if_child_module(metric_class):
+    """ Test that if a metric is a child module all values gets moved to the correct device """
+    class TestModule(LightningModule):
+        def __init__(self):
+            super().__init__()
+            self.metric = metric_class()
+
+    module = TestModule()
+
+    assert module.device == module.metric.device
+    if isinstance(module.metric.x, Tensor):
+        assert module.device == module.metric.x.device
+
+    module.to(device="cuda")
+
+    assert module.device == module.metric.device
+    if isinstance(module.metric.x, Tensor):
+        assert module.device == module.metric.x.device
+

--- a/tests/bases/test_metric.py
+++ b/tests/bases/test_metric.py
@@ -19,7 +19,7 @@ import numpy as np
 import pytest
 import torch
 from pytorch_lightning import LightningModule
-from torch import nn, tensor, Tensor
+from torch import Tensor, nn, tensor
 
 from tests.helpers import _LIGHTNING_GREATER_EQUAL_1_3, seed_all
 from tests.helpers.testers import DummyListMetric, DummyMetric, DummyMetricMultiOutput, DummyMetricSum

--- a/tests/bases/test_metric.py
+++ b/tests/bases/test_metric.py
@@ -18,8 +18,8 @@ import cloudpickle
 import numpy as np
 import pytest
 import torch
-from torch import nn, tensor
 from pytorch_lightning import LightningModule
+from torch import nn, tensor
 from torch.functional import Tensor
 
 from tests.helpers import _LIGHTNING_GREATER_EQUAL_1_3, seed_all
@@ -333,7 +333,8 @@ def test_forward_and_compute_to_device(metric_class):
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="Test requires GPU.")
 @pytest.mark.parametrize("metric_class", [DummyMetricSum, DummyMetricMultiOutput])
 def test_device_if_child_module(metric_class):
-    """ Test that if a metric is a child module all values gets moved to the correct device """
+    """Test that if a metric is a child module all values gets moved to the correct device."""
+
     class TestModule(LightningModule):
         def __init__(self):
             super().__init__()

--- a/tests/bases/test_metric.py
+++ b/tests/bases/test_metric.py
@@ -18,7 +18,6 @@ import cloudpickle
 import numpy as np
 import pytest
 import torch
-from pytorch_lightning import LightningModule
 from torch import Tensor, nn, tensor
 
 from tests.helpers import _LIGHTNING_GREATER_EQUAL_1_3, seed_all
@@ -334,10 +333,15 @@ def test_forward_and_compute_to_device(metric_class):
 def test_device_if_child_module(metric_class):
     """Test that if a metric is a child module all values gets moved to the correct device."""
 
-    class TestModule(LightningModule):
+    class TestModule(nn.Module):
         def __init__(self):
             super().__init__()
             self.metric = metric_class()
+            self.register_buffer("dummy", torch.zeros(1))
+
+        @property
+        def device(self):
+            return self.dummy.device
 
     module = TestModule()
 

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -506,22 +506,18 @@ class Metric(Module, ABC):
                 this._defaults[key] = [fn(v) for v in value]
 
             current_val = getattr(this, key)
-            device = None
             if isinstance(current_val, Tensor):
-                new_val = fn(current_val)
-                setattr(this, key, new_val)
-                device = new_val.device
+                setattr(this, key, fn(current_val))
             elif isinstance(current_val, Sequence):
-                new_val = [fn(cur_v) for cur_v in current_val]
-                setattr(this, key, new_val)
-                device = new_val[0].device if new_val else None
+                setattr(this, key, [fn(cur_v) for cur_v in current_val])
             else:
                 raise TypeError(
                     "Expected metric state to be either a Tensor" f"or a list of Tensor, but encountered {current_val}"
                 )
 
-            # make sure to update the device attribute
-            if device is not None: self._device = device
+        # make sure to update the device attribute
+        # if the dummy tensor moves device by fn function we should also update the attribute
+        self._device = fn(torch.zeros(1, device=self.device)).device
 
         # Additional apply to forward cache and computed attributes (may be nested)
         if this._computed is not None:


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?

Fixes https://github.com/PyTorchLightning/metrics/issues/531
Currently if a metric is a child of a module, the `device` property (only the property, the metric states are still correctly updated) of the metric will not get properly update (only if `.cuda()`, `.cpu()`, `to()` is directly called on the metric) when calling `.cuda()` on the module. This PR fixes it.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
