### PR TITLE
Create example for MAP metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,16 +23,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix empty predictions in MAP metric ([#594](https://github.com/PyTorchLightning/metrics/pull/594))
+
 
 ## [0.6.0] - 2021-10-28
 
 ### Added
 
 - Added audio metrics:
-  - Perceptual Evaluation of Speech Quality (PESQ) ([#353](https://github.com/PyTorchLightning/metrics/issues/353))
-  - Short Term Objective Intelligibility (STOI) ([#353](https://github.com/PyTorchLightning/metrics/issues/353))
+  - Perceptual Evaluation of Speech Quality (PESQ) ([#353](https://github.com/PyTorchLightning/metrics/pull/353))
+  - Short Term Objective Intelligibility (STOI) ([#353](https://github.com/PyTorchLightning/metrics/pull/353))
 - Added Information retrieval metrics:
-  - `RetrievalRPrecision` ([#577](https://github.com/PyTorchLightning/metrics/pull/577/))
+  - `RetrievalRPrecision` ([#577](https://github.com/PyTorchLightning/metrics/pull/577))
   - `RetrievalHitRate` ([#576](https://github.com/PyTorchLightning/metrics/pull/576))
 - Added NLP metrics:
   - `SacreBLEUScore` ([#546](https://github.com/PyTorchLightning/metrics/pull/546))

--- a/tests/detection/test_map.py
+++ b/tests/detection/test_map.py
@@ -25,7 +25,7 @@ from torchmetrics.utilities.imports import (
     _TORCHVISION_GREATER_EQUAL_0_8,
 )
 
-Input = namedtuple("Input", ["preds", "target", "num_classes"])
+Input = namedtuple("Input", ["preds", "target"])
 
 _inputs = Input(
     preds=[
@@ -100,8 +100,7 @@ _inputs = Input(
                 labels=torch.IntTensor([5]),
             ),  # coco image id 133
         ],
-    ],
-    num_classes=6,
+    ]
 )
 
 

--- a/tests/detection/test_map.py
+++ b/tests/detection/test_map.py
@@ -100,7 +100,7 @@ _inputs = Input(
                 labels=torch.IntTensor([5]),
             ),  # coco image id 133
         ],
-    ]
+    ],
 )
 
 

--- a/tests/detection/test_map.py
+++ b/tests/detection/test_map.py
@@ -207,6 +207,23 @@ def test_error_on_wrong_init():
 
 
 @pytest.mark.skipif(_pytest_condition, reason="test requires that pycocotools and torchvision=>0.8.0 is installed")
+def test_empty_preds():
+    """Test empty predictions."""
+
+    metric = MAP()
+
+    metric.update(
+        [
+            dict(boxes=torch.Tensor([[]]), scores=torch.Tensor([]), labels=torch.IntTensor([])),
+        ],
+        [
+            dict(boxes=torch.Tensor([[214.1500, 41.2900, 562.4100, 285.0700]]), labels=torch.IntTensor([4])),
+        ],
+    )
+    metric.compute()
+
+
+@pytest.mark.skipif(_pytest_condition, reason="test requires that pycocotools and torchvision=>0.8.0 is installed")
 def test_error_on_wrong_input():
     """Test class input validation."""
 

--- a/tm_examples/detection_map.py
+++ b/tm_examples/detection_map.py
@@ -25,6 +25,8 @@ preds = [
         # The boxes keyword should contain an [N,4] tensor,
         # where N is the number of detected boxes and ...
         boxes=torch.Tensor([[258.0, 41.0, 606.0, 285.0]]),
+        # The scores keyword should contain an [N,] tensor where
+        # each element is confidence score between 0 and 1
         scores=torch.Tensor([0.536]),
         labels=torch.IntTensor([0]),
     )

--- a/tm_examples/detection_map.py
+++ b/tm_examples/detection_map.py
@@ -1,3 +1,21 @@
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""An example of how to the predictions and target should be defined for the
+MAP object detection metric
+To run: python detection_map.py
+"""
+
 import torch
 
 from torchmetrics import MAP

--- a/tm_examples/detection_map.py
+++ b/tm_examples/detection_map.py
@@ -4,7 +4,7 @@ from torchmetrics import MAP
 
 preds = [
     dict(
-        boxes=torch.Tensor([[258., 41., 606., 285.]]),
+        boxes=torch.Tensor([[258.0, 41.0, 606.0, 285.0]]),
         scores=torch.Tensor([0.536]),
         labels=torch.IntTensor([0]),
     )
@@ -12,7 +12,7 @@ preds = [
 
 target = [
     dict(
-        boxes=torch.Tensor([[214., 41., 562., 285.]]),
+        boxes=torch.Tensor([[214.0, 41.0, 562.0, 285.0]]),
         labels=torch.IntTensor([0]),
     )
 ]
@@ -21,4 +21,4 @@ if __name__ == "__main__":
     metric = MAP()
     metric.update(preds, target)
     result = metric.compute()
-    print(result['map'].cpu().item())
+    print(result["map"].cpu().item())

--- a/tm_examples/detection_map.py
+++ b/tm_examples/detection_map.py
@@ -39,4 +39,4 @@ if __name__ == "__main__":
     metric = MAP()
     metric.update(preds, target)
     result = metric.compute()
-    print(result["map"].cpu().item())
+    print(result)

--- a/tm_examples/detection_map.py
+++ b/tm_examples/detection_map.py
@@ -49,12 +49,12 @@ target = [
 ]
 
 if __name__ == "__main__":
-    # initialize metric
+    # Initialize metric
     metric = MAP()
 
-    # update metric with predictions and respective ground truth
+    # Update metric with predictions and respective ground truth
     metric.update(preds, target)
 
-    # after adding the data, compute the results
+    # Compute the results
     result = metric.compute()
     print(result)

--- a/tm_examples/detection_map.py
+++ b/tm_examples/detection_map.py
@@ -18,6 +18,8 @@ import torch
 
 from torchmetrics import MAP
 
+# Preds should be a list of elements, where each element is a dict
+# containing 3 keys: boxes, scores, labels
 preds = [
     dict(
         boxes=torch.Tensor([[258.0, 41.0, 606.0, 285.0]]),

--- a/tm_examples/detection_map.py
+++ b/tm_examples/detection_map.py
@@ -22,6 +22,8 @@ from torchmetrics import MAP
 # containing 3 keys: boxes, scores, labels
 preds = [
     dict(
+        # The boxes keyword should contain an [N,4] tensor,
+        # where N is the number of detected boxes and ...
         boxes=torch.Tensor([[258.0, 41.0, 606.0, 285.0]]),
         scores=torch.Tensor([0.536]),
         labels=torch.IntTensor([0]),

--- a/tm_examples/detection_map.py
+++ b/tm_examples/detection_map.py
@@ -25,11 +25,14 @@ from torchmetrics import MAP
 preds = [
     dict(
         # The boxes keyword should contain an [N,4] tensor,
-        # where N is the number of detected boxes and ...
+        # where N is the number of detected boxes with boxes of the format
+        # [xmin, ymin, xmax, ymax] in absolute image coordinates
         boxes=torch.Tensor([[258.0, 41.0, 606.0, 285.0]]),
         # The scores keyword should contain an [N,] tensor where
         # each element is confidence score between 0 and 1
         scores=torch.Tensor([0.536]),
+        # The labels keyword should contain an [N,] tensor
+        # with integers of the predicted classes
         labels=torch.IntTensor([0]),
     )
 ]
@@ -37,7 +40,7 @@ preds = [
 # Target should be a list of elements, where each element is a dict
 # containing 2 keys: boxes and labels. Each keyword should be formatted
 # similar to the preds argument. The number of elements in preds and
-# target should match
+# target need to match
 target = [
     dict(
         boxes=torch.Tensor([[214.0, 41.0, 562.0, 285.0]]),
@@ -46,7 +49,12 @@ target = [
 ]
 
 if __name__ == "__main__":
+    # initialize metric
     metric = MAP()
+
+    # update metric with predictions and respective ground truth
     metric.update(preds, target)
+
+    # after adding the data, compute the results
     result = metric.compute()
     print(result)

--- a/tm_examples/detection_map.py
+++ b/tm_examples/detection_map.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """An example of how to the predictions and target should be defined for the MAP object detection metric To run:
-python detection_map.py."""
+
+python detection_map.py.
+"""
 
 import torch
 

--- a/tm_examples/detection_map.py
+++ b/tm_examples/detection_map.py
@@ -1,29 +1,24 @@
-from collections import namedtuple
-
 import torch
 
 from torchmetrics import MAP
 
-Input = namedtuple("Input", ["preds", "target"])
+preds = [
+    dict(
+        boxes=torch.Tensor([[258., 41., 606., 285.]]),
+        scores=torch.Tensor([0.536]),
+        labels=torch.IntTensor([0]),
+    )
+]
 
-inputs = Input(
-    preds=[
-        dict(
-            boxes=torch.Tensor([[258., 41., 606., 285.]]),
-            scores=torch.Tensor([0.536]),
-            labels=torch.IntTensor([0]),
-        )  # coco image id 42
-    ],
-    target=[
-        dict(
-            boxes=torch.Tensor([[214., 41., 562., 285.]]),
-            labels=torch.IntTensor([0]),
-        )  # coco image id 42
-    ]
-)
+target = [
+    dict(
+        boxes=torch.Tensor([[214., 41., 562., 285.]]),
+        labels=torch.IntTensor([0]),
+    )
+]
 
 if __name__ == "__main__":
-    metric = MAP(class_metrics=True)
-    metric.update(inputs.preds, inputs.target)
+    metric = MAP()
+    metric.update(preds, target)
     result = metric.compute()
-    print(result)
+    print(result['map'].cpu().item())

--- a/tm_examples/detection_map.py
+++ b/tm_examples/detection_map.py
@@ -1,0 +1,29 @@
+from collections import namedtuple
+
+import torch
+
+from torchmetrics import MAP
+
+Input = namedtuple("Input", ["preds", "target"])
+
+inputs = Input(
+    preds=[
+        dict(
+            boxes=torch.Tensor([[258., 41., 606., 285.]]),
+            scores=torch.Tensor([0.536]),
+            labels=torch.IntTensor([0]),
+        )  # coco image id 42
+    ],
+    target=[
+        dict(
+            boxes=torch.Tensor([[214., 41., 562., 285.]]),
+            labels=torch.IntTensor([0]),
+        )  # coco image id 42
+    ]
+)
+
+if __name__ == "__main__":
+    metric = MAP(class_metrics=True)
+    metric.update(inputs.preds, inputs.target)
+    result = metric.compute()
+    print(result)

--- a/tm_examples/detection_map.py
+++ b/tm_examples/detection_map.py
@@ -30,6 +30,10 @@ preds = [
     )
 ]
 
+# Target should be a list of elements, where each element is a dict
+# containing 2 keys: boxes and labels. Each keyword should be formatted
+# similar to the preds argument. The number of elements in preds and
+# target should match
 target = [
     dict(
         boxes=torch.Tensor([[214.0, 41.0, 562.0, 285.0]]),

--- a/tm_examples/detection_map.py
+++ b/tm_examples/detection_map.py
@@ -11,10 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""An example of how to the predictions and target should be defined for the
-MAP object detection metric
-To run: python detection_map.py
-"""
+"""An example of how to the predictions and target should be defined for the MAP object detection metric To run:
+python detection_map.py."""
 
 import torch
 

--- a/torchmetrics/detection/map.py
+++ b/torchmetrics/detection/map.py
@@ -365,7 +365,7 @@ class MAP(Metric):
         annotations = []
         annotation_id = 1  # has to start with 1, otherwise COCOEval results are wrong
 
-        boxes = [box_convert(box, in_fmt="xyxy", out_fmt="xywh") for box in boxes]
+        boxes = [box_convert(box, in_fmt="xyxy", out_fmt="xywh") if boxes[0].size(1) == 4 else box for box in boxes]
         for image_id, (image_boxes, image_labels) in enumerate(zip(boxes, labels)):
             image_boxes = image_boxes.cpu().tolist()
             image_labels = image_labels.cpu().tolist()

--- a/torchmetrics/detection/map.py
+++ b/torchmetrics/detection/map.py
@@ -150,6 +150,9 @@ class MAP(Metric):
     (xmin-top left, ymin-top left, xmax-bottom right, ymax-bottom right).
     See the :meth:`update` method for more information about the input format to this metric.
 
+    For an example on how to use this metric check the `torchmetrics examples\
+    <https://github.com/PyTorchLightning/metrics/blob/master/tm_examples/detection_map.py>`_
+
     .. note::
         This metric is a wrapper for the
         `pycocotools <https://github.com/cocodataset/cocoapi/tree/master/PythonAPI/pycocotools>`_,


### PR DESCRIPTION
## What does this PR do?

As suggested in https://github.com/PyTorchLightning/metrics/pull/467, this adds an example on how to use the MAP metric for object detection.

The example is minimal and based on the unit test for this metric.