### PR TITLE
Fix a docstring for the format of ROUGE input

### DIFF
--- a/torchmetrics/functional/text/rouge.py
+++ b/torchmetrics/functional/text/rouge.py
@@ -261,8 +261,8 @@ def rouge_score(
         Python dictionary of rouge scores for each input rouge key.
 
     Example:
-        >>> targets = "Is your name John".split()
-        >>> preds = "My name is John".split()
+        >>> targets = "Is your name John"
+        >>> preds = "My name is John"
         >>> from pprint import pprint
         >>> pprint(rouge_score(preds, targets))  # doctest: +NORMALIZE_WHITESPACE +SKIP
         {'rouge1_fmeasure': 0.25,

--- a/torchmetrics/functional/text/rouge.py
+++ b/torchmetrics/functional/text/rouge.py
@@ -248,9 +248,9 @@ def rouge_score(
 
     Args:
         preds:
-            An iterable of predicted sentences.
+            An iterable of predicted sentences or a single predicted sentence.
         targets:
-            An iterable of target sentences.
+            An iterable of target sentences or a single target sentence.
         use_stemmer:
             Use Porter stemmer to strip word suffixes to improve matching.
         rouge_keys:

--- a/torchmetrics/text/rouge.py
+++ b/torchmetrics/text/rouge.py
@@ -50,8 +50,8 @@ class ROUGEScore(Metric):
 
     Example:
 
-        >>> targets = "Is your name John".split()
-        >>> preds = "My name is John".split()
+        >>> targets = "Is your name John"
+        >>> preds = "My name is John"
         >>> rouge = ROUGEScore()   # doctest: +SKIP
         >>> from pprint import pprint
         >>> pprint(rouge(preds, targets))  # doctest: +NORMALIZE_WHITESPACE +SKIP

--- a/torchmetrics/text/rouge.py
+++ b/torchmetrics/text/rouge.py
@@ -126,8 +126,8 @@ class ROUGEScore(Metric):
         """Compute rouge scores.
 
         Args:
-            preds: An iterable of predicted sentences.
-            targets: An iterable of target sentences.
+            preds: An iterable of predicted sentences or a single predicted sentence.
+            targets: An iterable of target sentences or a single target sentence.
         """
 
         if isinstance(preds, str):


### PR DESCRIPTION
# Before submitting

- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?

## What does this PR do?

The current implementation of the ROUGE score expects the input is not tokenized, while the docstring suggests the input hypotheses and references to be tokenized. This PR fixes this divergence.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

@Borda @SkafteNicki 

## Did you have fun?

Make sure you had fun coding 🙃
