### PR TITLE
Update the number of metrics: 25+ -> 60+ in the quickstart page

### DIFF
--- a/docs/source/pages/quickstart.rst
+++ b/docs/source/pages/quickstart.rst
@@ -2,7 +2,7 @@
 Quick Start
 ###########
 
-TorchMetrics is a collection of 25+ PyTorch metrics implementations and an easy-to-use API to create custom metrics. It offers:
+TorchMetrics is a collection of 60+ PyTorch metrics implementations and an easy-to-use API to create custom metrics. It offers:
 
 * A standardized interface to increase reproducability
 * Reduces Boilerplate


### PR DESCRIPTION
## What does this PR do?

[Docs] This PR updates the number of metrics in `docs/source/pages/quickstart.rst` from 25+ to 60+ metrics.

## Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

@Borda 
