### PR TITLE
MAP metric, fix metric for CUDA execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `torch.sort` currently does not support bool dtype on CUDA ([#665](https://github.com/PyTorchLightning/metrics/pull/665))
 
 
+- Fixed initialization of tensors to be on correct device for `MAP` metric ([#673](https://github.com/PyTorchLightning/metrics/pull/673))
+
 
 ## [0.6.1] - 2021-12-06
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -278,8 +278,7 @@ def setup(app):
 
 # copy all notebooks to local folder
 path_nbs = os.path.join(_PATH_HERE, "notebooks")
-if not os.path.isdir(path_nbs):
-    os.mkdir(path_nbs)
+os.makedirs(path_nbs, exist_ok=True)
 for path_ipynb in glob.glob(os.path.join(_PATH_ROOT, "notebooks", "*.ipynb")):
     path_ipynb2 = os.path.join(path_nbs, os.path.basename(path_ipynb))
     shutil.copy(path_ipynb, path_ipynb2)

--- a/requirements/detection.txt
+++ b/requirements/detection.txt
@@ -1,2 +1,1 @@
-pycocotools>=2.0.2
 torchvision

--- a/tests/helpers/testers.py
+++ b/tests/helpers/testers.py
@@ -25,6 +25,7 @@ from torch.multiprocessing import Pool, set_start_method
 
 from torchmetrics import Metric
 from torchmetrics.detection.map import MAPMetricResults
+from torchmetrics.utilities.data import apply_to_collection
 
 try:
     set_start_method("spawn")
@@ -164,10 +165,8 @@ def _class_test(
 
     # move to device
     metric = metric.to(device)
-
-    if isinstance(preds, torch.Tensor):
-        preds = preds.to(device)
-        target = target.to(device)
+    preds = apply_to_collection(preds, Tensor, lambda x: x.to(device))
+    target = apply_to_collection(target, Tensor, lambda x: x.to(device))
 
     kwargs_update = {k: v.to(device) if isinstance(v, Tensor) else v for k, v in kwargs_update.items()}
 

--- a/torchmetrics/detection/map.py
+++ b/torchmetrics/detection/map.py
@@ -423,10 +423,10 @@ class MAP(Metric):
         nb_iou_thrs = len(self.iou_thresholds)
         nb_gt = len(gt)
         nb_det = len(det)
-        gt_matches = torch.zeros((nb_iou_thrs, nb_gt), dtype=torch.bool)
-        det_matches = torch.zeros((nb_iou_thrs, nb_det), dtype=torch.bool)
+        gt_matches = torch.zeros((nb_iou_thrs, nb_gt), dtype=torch.bool, device=self.device)
+        det_matches = torch.zeros((nb_iou_thrs, nb_det), dtype=torch.bool, device=self.device)
         gt_ignore = ignore_area_sorted
-        det_ignore = torch.zeros((nb_iou_thrs, nb_det), dtype=torch.bool)
+        det_ignore = torch.zeros((nb_iou_thrs, nb_det), dtype=torch.bool, device=self.device)
         if torch.numel(ious) > 0:
             for idx_iou, t in enumerate(self.iou_thresholds):
                 for idx_det in range(nb_det):
@@ -564,6 +564,12 @@ class MAP(Metric):
         precision = -torch.ones((nb_iou_thrs, nb_rec_thrs, nb_classes, nb_bbox_areas, nb_max_det_thrs))
         recall = -torch.ones((nb_iou_thrs, nb_classes, nb_bbox_areas, nb_max_det_thrs))
         scores = -torch.ones((nb_iou_thrs, nb_rec_thrs, nb_classes, nb_bbox_areas, nb_max_det_thrs))
+
+        # move tensors if necessary
+        if self.max_detection_thresholds.device != self.device:
+            self.max_detection_thresholds = self.max_detection_thresholds.to(self.device)
+        if self.rec_thresholds.device != self.device:
+            self.rec_thresholds = self.rec_thresholds.to(self.device)
 
         # retrieve E at each category, area range, and max number of detections
         for idx_cls in range(nb_classes):

--- a/torchmetrics/detection/map.py
+++ b/torchmetrics/detection/map.py
@@ -566,10 +566,8 @@ class MAP(Metric):
         scores = -torch.ones((nb_iou_thrs, nb_rec_thrs, nb_classes, nb_bbox_areas, nb_max_det_thrs))
 
         # move tensors if necessary
-        if self.max_detection_thresholds.device != self.device:
-            self.max_detection_thresholds = self.max_detection_thresholds.to(self.device)
-        if self.rec_thresholds.device != self.device:
-            self.rec_thresholds = self.rec_thresholds.to(self.device)
+        self.max_detection_thresholds = self.max_detection_thresholds.to(self.device)
+        self.rec_thresholds = self.rec_thresholds.to(self.device)
 
         # retrieve E at each category, area range, and max number of detections
         for idx_cls in range(nb_classes):

--- a/torchmetrics/detection/map.py
+++ b/torchmetrics/detection/map.py
@@ -436,7 +436,7 @@ class MAP(Metric):
                         det_matches[idx_iou, idx_det] = True
                         gt_matches[idx_iou, m] = True
         # set unmatched detections outside of area range to ignore
-        det_areas = box_area(det)
+        det_areas = box_area(det).to(self.device)
         det_ignore_area = (det_areas < area_range[0]) | (det_areas > area_range[1])
         ar = det_ignore_area.reshape((1, nb_det))
         det_ignore = torch.logical_or(


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where the new MAP implementation cannot be executed on CUDA devices.
The tensors have to be initialized/moved to the correct CUDA device.
Fixes #671

## Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

🎉
