### PR TITLE
Updated docs in PrecisionRecallCurve and AveragePrecision

### DIFF
--- a/torchmetrics/classification/avg_precision.py
+++ b/torchmetrics/classification/avg_precision.py
@@ -67,7 +67,7 @@ class AveragePrecision(Metric):
 
     Example (binary case):
         >>> from torchmetrics import AveragePrecision
-        >>> pred = torch.tensor([0, 1, 2, 3])
+        >>> pred = torch.tensor([0, 0.1, 0.8, 0.4])
         >>> target = torch.tensor([0, 1, 1, 1])
         >>> average_precision = AveragePrecision(pos_label=1)
         >>> average_precision(pred, target)

--- a/torchmetrics/classification/precision_recall_curve.py
+++ b/torchmetrics/classification/precision_recall_curve.py
@@ -53,16 +53,16 @@ class PrecisionRecallCurve(Metric):
 
     Example (binary case):
         >>> from torchmetrics import PrecisionRecallCurve
-        >>> pred = torch.tensor([0, 1, 2, 3])
+        >>> pred = torch.tensor([0, 0.1, 0.8, 0.4])
         >>> target = torch.tensor([0, 1, 1, 0])
         >>> pr_curve = PrecisionRecallCurve(pos_label=1)
         >>> precision, recall, thresholds = pr_curve(pred, target)
         >>> precision
-        tensor([0.6667, 0.5000, 0.0000, 1.0000])
+        tensor([0.6667, 0.5000, 1.0000, 1.0000])
         >>> recall
-        tensor([1.0000, 0.5000, 0.0000, 0.0000])
+        tensor([1.0000, 0.5000, 0.5000, 0.0000])
         >>> thresholds
-        tensor([1, 2, 3])
+        tensor([0.1000, 0.4000, 0.8000])
 
     Example (multiclass case):
         >>> pred = torch.tensor([[0.75, 0.05, 0.05, 0.05, 0.05],


### PR DESCRIPTION
## What does this PR do?
Updates the docstring for the binary example in both `PrecisionRecallCurve` and `AveragePrecision` objects to better reflect input prediction values. For the `PrecisionRecallCurve`, we also update the output values for `precision`, `recall`, and `thresholds` to align the calculation with the new input.

For `PrecisionRecallCurve`, I also verified the inputs and outputs match the values also observed in the `precision_recall_curve` object from sklearn, and they do, yay!
<img width="654" alt="image" src="https://user-images.githubusercontent.com/8564748/147976605-befbb15c-5a48-4803-8732-3153615b7efe.png">


Fixes #701 

## Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs? (I believe this happens automagically as stated in the contributor guideline)
- [ ] Did you write any new necessary tests? No

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
![](https://media.giphy.com/media/lI9sDSzYgPTQUasSIa/giphy.gif)

Make sure you had fun coding 🙃
