### PR TITLE
Removed input_order from text unit tests

### DIFF
--- a/tests/text/test_bleu.py
+++ b/tests/text/test_bleu.py
@@ -18,7 +18,7 @@ import pytest
 from nltk.translate.bleu_score import SmoothingFunction, corpus_bleu
 from torch import tensor
 
-from tests.text.helpers import INPUT_ORDER, TextTester
+from tests.text.helpers import TextTester
 from tests.text.inputs import _inputs_multiple_references
 from torchmetrics.functional.text.bleu import bleu_score
 from torchmetrics.text.bleu import BLEUScore
@@ -67,7 +67,6 @@ class TestBLEUScore(TextTester):
             sk_metric=compute_bleu_metric_nltk,
             dist_sync_on_step=dist_sync_on_step,
             metric_args=metric_args,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
     def test_bleu_score_functional(self, preds, targets, weights, n_gram, smooth_func, smooth):
@@ -80,7 +79,6 @@ class TestBLEUScore(TextTester):
             metric_functional=bleu_score,
             sk_metric=compute_bleu_metric_nltk,
             metric_args=metric_args,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
     def test_bleu_score_differentiability(self, preds, targets, weights, n_gram, smooth_func, smooth):
@@ -92,7 +90,6 @@ class TestBLEUScore(TextTester):
             metric_module=BLEUScore,
             metric_functional=bleu_score,
             metric_args=metric_args,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
 

--- a/tests/text/test_cer.py
+++ b/tests/text/test_cer.py
@@ -2,7 +2,7 @@ from typing import Callable, List, Union
 
 import pytest
 
-from tests.text.helpers import INPUT_ORDER, TextTester
+from tests.text.helpers import TextTester
 from tests.text.inputs import _inputs_error_rate_batch_size_1, _inputs_error_rate_batch_size_2
 from torchmetrics.functional.text.cer import char_error_rate
 from torchmetrics.text.cer import CharErrorRate
@@ -41,7 +41,6 @@ class TestCharErrorRate(TextTester):
             metric_class=CharErrorRate,
             sk_metric=compare_fn,
             dist_sync_on_step=dist_sync_on_step,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
     def test_cer_functional(self, preds, targets):
@@ -51,7 +50,6 @@ class TestCharErrorRate(TextTester):
             targets,
             metric_functional=char_error_rate,
             sk_metric=compare_fn,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
     def test_cer_differentiability(self, preds, targets):
@@ -61,5 +59,4 @@ class TestCharErrorRate(TextTester):
             targets=targets,
             metric_module=CharErrorRate,
             metric_functional=char_error_rate,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )

--- a/tests/text/test_chrf.py
+++ b/tests/text/test_chrf.py
@@ -4,7 +4,7 @@ from typing import Sequence
 import pytest
 from torch import Tensor, tensor
 
-from tests.text.helpers import INPUT_ORDER, TextTester
+from tests.text.helpers import TextTester
 from tests.text.inputs import _inputs_multiple_references, _inputs_single_sentence_multiple_references
 from torchmetrics.functional.text.chrf import chrf_score
 from torchmetrics.text.chrf import CHRFScore
@@ -71,7 +71,6 @@ class TestCHRFScore(TextTester):
             sk_metric=nltk_metric,
             dist_sync_on_step=dist_sync_on_step,
             metric_args=metric_args,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
     def test_chrf_score_functional(self, preds, targets, char_order, word_order, lowercase, whitespace):
@@ -91,7 +90,6 @@ class TestCHRFScore(TextTester):
             metric_functional=chrf_score,
             sk_metric=nltk_metric,
             metric_args=metric_args,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
     def test_chrf_score_differentiability(self, preds, targets, char_order, word_order, lowercase, whitespace):
@@ -108,7 +106,6 @@ class TestCHRFScore(TextTester):
             metric_module=CHRFScore,
             metric_functional=chrf_score,
             metric_args=metric_args,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
 

--- a/tests/text/test_mer.py
+++ b/tests/text/test_mer.py
@@ -2,7 +2,7 @@ from typing import Callable, List, Union
 
 import pytest
 
-from tests.text.helpers import INPUT_ORDER, TextTester
+from tests.text.helpers import TextTester
 from tests.text.inputs import _inputs_error_rate_batch_size_1, _inputs_error_rate_batch_size_2
 from torchmetrics.utilities.imports import _JIWER_AVAILABLE
 
@@ -39,7 +39,6 @@ class TestMatchErrorRate(TextTester):
             metric_class=MatchErrorRate,
             sk_metric=_compute_mer_metric_jiwer,
             dist_sync_on_step=dist_sync_on_step,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
     def test_mer_functional(self, preds, targets):
@@ -49,7 +48,6 @@ class TestMatchErrorRate(TextTester):
             targets,
             metric_functional=match_error_rate,
             sk_metric=_compute_mer_metric_jiwer,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
     def test_mer_differentiability(self, preds, targets):
@@ -59,5 +57,4 @@ class TestMatchErrorRate(TextTester):
             targets=targets,
             metric_module=MatchErrorRate,
             metric_functional=match_error_rate,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )

--- a/tests/text/test_rouge.py
+++ b/tests/text/test_rouge.py
@@ -18,7 +18,7 @@ from typing import Sequence
 import pytest
 import torch
 
-from tests.text.helpers import INPUT_ORDER, TextTester
+from tests.text.helpers import TextTester
 from tests.text.inputs import _inputs_multiple_references, _inputs_single_sentence_single_reference
 from torchmetrics.functional.text.rouge import rouge_score
 from torchmetrics.text.rouge import ROUGEScore
@@ -120,7 +120,6 @@ class TestROUGEScore(TextTester):
             sk_metric=rouge_metric,
             dist_sync_on_step=dist_sync_on_step,
             metric_args=metric_args,
-            input_order=INPUT_ORDER.PREDS_FIRST,
             key=pl_rouge_metric_key,
         )
 
@@ -137,7 +136,6 @@ class TestROUGEScore(TextTester):
             metric_functional=rouge_score,
             sk_metric=rouge_metric,
             metric_args=metric_args,
-            input_order=INPUT_ORDER.PREDS_FIRST,
             key=pl_rouge_metric_key,
         )
 

--- a/tests/text/test_sacre_bleu.py
+++ b/tests/text/test_sacre_bleu.py
@@ -18,7 +18,7 @@ from typing import Sequence
 import pytest
 from torch import Tensor, tensor
 
-from tests.text.helpers import INPUT_ORDER, TextTester
+from tests.text.helpers import TextTester
 from tests.text.inputs import _inputs_multiple_references
 from torchmetrics.functional.text.sacre_bleu import sacre_bleu_score
 from torchmetrics.text.sacre_bleu import SacreBLEUScore
@@ -61,7 +61,6 @@ class TestSacreBLEUScore(TextTester):
             sk_metric=original_sacrebleu,
             dist_sync_on_step=dist_sync_on_step,
             metric_args=metric_args,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
     def test_bleu_score_functional(self, preds, targets, tokenize, lowercase):
@@ -74,7 +73,6 @@ class TestSacreBLEUScore(TextTester):
             metric_functional=sacre_bleu_score,
             sk_metric=original_sacrebleu,
             metric_args=metric_args,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
     def test_bleu_score_differentiability(self, preds, targets, tokenize, lowercase):
@@ -86,5 +84,4 @@ class TestSacreBLEUScore(TextTester):
             metric_module=SacreBLEUScore,
             metric_functional=sacre_bleu_score,
             metric_args=metric_args,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )

--- a/tests/text/test_ter.py
+++ b/tests/text/test_ter.py
@@ -4,7 +4,7 @@ from typing import Sequence
 import pytest
 from torch import Tensor, tensor
 
-from tests.text.helpers import INPUT_ORDER, TextTester
+from tests.text.helpers import TextTester
 from tests.text.inputs import _inputs_multiple_references, _inputs_single_sentence_multiple_references
 from torchmetrics.functional.text.ter import ter
 from torchmetrics.text.ter import TER
@@ -75,7 +75,6 @@ class TestTER(TextTester):
             sk_metric=nltk_metric,
             dist_sync_on_step=dist_sync_on_step,
             metric_args=metric_args,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
     def test_ter_score_functional(self, preds, targets, normalize, no_punctuation, asian_support, lowercase):
@@ -99,7 +98,6 @@ class TestTER(TextTester):
             metric_functional=ter,
             sk_metric=nltk_metric,
             metric_args=metric_args,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
     def test_chrf_score_differentiability(self, preds, targets, normalize, no_punctuation, asian_support, lowercase):
@@ -116,7 +114,6 @@ class TestTER(TextTester):
             metric_module=TER,
             metric_functional=ter,
             metric_args=metric_args,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
 

--- a/tests/text/test_wer.py
+++ b/tests/text/test_wer.py
@@ -2,7 +2,7 @@ from typing import Callable, List, Union
 
 import pytest
 
-from tests.text.helpers import INPUT_ORDER, TextTester
+from tests.text.helpers import TextTester
 from tests.text.inputs import _inputs_error_rate_batch_size_1, _inputs_error_rate_batch_size_2
 from torchmetrics.utilities.imports import _JIWER_AVAILABLE
 
@@ -39,7 +39,6 @@ class TestWER(TextTester):
             metric_class=WER,
             sk_metric=_compute_wer_metric_jiwer,
             dist_sync_on_step=dist_sync_on_step,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
     def test_wer_functional(self, preds, targets):
@@ -49,7 +48,6 @@ class TestWER(TextTester):
             targets,
             metric_functional=wer,
             sk_metric=_compute_wer_metric_jiwer,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
     def test_wer_differentiability(self, preds, targets):
@@ -59,5 +57,4 @@ class TestWER(TextTester):
             targets=targets,
             metric_module=WER,
             metric_functional=wer,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )

--- a/tests/text/test_wil.py
+++ b/tests/text/test_wil.py
@@ -3,7 +3,7 @@ from typing import List, Union
 import pytest
 from jiwer import wil
 
-from tests.text.helpers import INPUT_ORDER, TextTester
+from tests.text.helpers import TextTester
 from tests.text.inputs import _inputs_error_rate_batch_size_1, _inputs_error_rate_batch_size_2
 from torchmetrics.functional.text.wil import word_information_lost
 from torchmetrics.text.wil import WordInfoLost
@@ -34,7 +34,6 @@ class TestWordInfoLost(TextTester):
             metric_class=WordInfoLost,
             sk_metric=_compute_wil_metric_jiwer,
             dist_sync_on_step=dist_sync_on_step,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
     def test_wil_functional(self, preds, targets):
@@ -44,7 +43,6 @@ class TestWordInfoLost(TextTester):
             targets,
             metric_functional=word_information_lost,
             sk_metric=_compute_wil_metric_jiwer,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
     def test_wil_differentiability(self, preds, targets):
@@ -54,5 +52,4 @@ class TestWordInfoLost(TextTester):
             targets=targets,
             metric_module=WordInfoLost,
             metric_functional=word_information_lost,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )

--- a/tests/text/test_wip.py
+++ b/tests/text/test_wip.py
@@ -3,7 +3,7 @@ from typing import List, Union
 import pytest
 from jiwer import wip
 
-from tests.text.helpers import INPUT_ORDER, TextTester
+from tests.text.helpers import TextTester
 from tests.text.inputs import _inputs_error_rate_batch_size_1, _inputs_error_rate_batch_size_2
 from torchmetrics.functional.text.wip import word_information_preserved
 from torchmetrics.text.wip import WordInfoPreserved
@@ -34,7 +34,6 @@ class TestWordInfoPreserved(TextTester):
             metric_class=WordInfoPreserved,
             sk_metric=_compute_wip_metric_jiwer,
             dist_sync_on_step=dist_sync_on_step,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
     def test_wip_functional(self, preds, targets):
@@ -44,7 +43,6 @@ class TestWordInfoPreserved(TextTester):
             targets,
             metric_functional=word_information_preserved,
             sk_metric=_compute_wip_metric_jiwer,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )
 
     def test_wip_differentiability(self, preds, targets):
@@ -54,5 +52,4 @@ class TestWordInfoPreserved(TextTester):
             targets=targets,
             metric_module=WordInfoPreserved,
             metric_functional=word_information_preserved,
-            input_order=INPUT_ORDER.PREDS_FIRST,
         )


### PR DESCRIPTION
## What does this PR do?

#### Historical Work:
The following issue was created to align input order for `preds` and `targets` in the text (NLG) module: https://github.com/PyTorchLightning/metrics/issues/686
The following PR was merged with the fix: https://github.com/PyTorchLightning/metrics/pull/696

Fixes #704 
The work in this PR removes references to `input_order` in the `torchmetrics.tests.text.helpers._class_test` and `torchmetrics.tests.text.helpers._functional_test`. All unit tests also remove this parameter from calls to these methods. All unit tests are passing locally.

## Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
![](https://media.giphy.com/media/LBgmyXjkls7gZ3ReTp/giphy-downsized.gif)
Make sure you had fun coding 🙃
