### PR TITLE
Rename of `manhatten` to `manhattan`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,7 +171,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `pairwise_cosine_similarity`
   - `pairwise_euclidean_distance`
   - `pairwise_linear_similarity`
-  - `pairwise_manhattan_distance`
+  - `pairwise_manhatten_distance`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,7 +171,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `pairwise_cosine_similarity`
   - `pairwise_euclidean_distance`
   - `pairwise_linear_similarity`
-  - `pairwise_manhatten_distance`
+  - `pairwise_manhattan_distance`
 
 ### Changed
 

--- a/docs/source/references/functional.rst
+++ b/docs/source/references/functional.rst
@@ -367,10 +367,10 @@ pairwise_linear_similarity [func]
     :noindex:
 
 
-pairwise_manhatten_distance [func]
+pairwise_manhattan_distance [func]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autofunction:: torchmetrics.functional.pairwise_manhatten_distance
+.. autofunction:: torchmetrics.functional.pairwise_manhattan_distance
     :noindex:
 
 

--- a/tests/pairwise/test_pairwise_distance.py
+++ b/tests/pairwise/test_pairwise_distance.py
@@ -24,7 +24,7 @@ from torchmetrics.functional import (
     pairwise_cosine_similarity,
     pairwise_euclidean_distance,
     pairwise_linear_similarity,
-    pairwise_manhatten_distance,
+    pairwise_manhattan_distance,
 )
 from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_1_7
 
@@ -71,7 +71,7 @@ def _sk_metric(x, y, sk_fn, reduction):
     [
         (pairwise_cosine_similarity, cosine_similarity),
         (pairwise_euclidean_distance, euclidean_distances),
-        (pairwise_manhatten_distance, manhattan_distances),
+        (pairwise_manhattan_distance, manhattan_distances),
         (pairwise_linear_similarity, linear_kernel),
     ],
 )
@@ -107,7 +107,7 @@ class TestPairwise(MetricTester):
 
 
 @pytest.mark.parametrize(
-    "metric", [pairwise_cosine_similarity, pairwise_euclidean_distance, pairwise_manhatten_distance]
+    "metric", [pairwise_cosine_similarity, pairwise_euclidean_distance, pairwise_manhattan_distance]
 )
 def test_error_on_wrong_shapes(metric):
     """Test errors are raised on wrong input."""

--- a/torchmetrics/functional/__init__.py
+++ b/torchmetrics/functional/__init__.py
@@ -44,6 +44,7 @@ from torchmetrics.functional.pairwise.cosine import pairwise_cosine_similarity
 from torchmetrics.functional.pairwise.euclidean import pairwise_euclidean_distance
 from torchmetrics.functional.pairwise.linear import pairwise_linear_similarity
 from torchmetrics.functional.pairwise.manhattan import pairwise_manhattan_distance
+from torchmetrics.functional.pairwise.manhatten import pairwise_manhatten_distance
 from torchmetrics.functional.regression.cosine_similarity import cosine_similarity
 from torchmetrics.functional.regression.explained_variance import explained_variance
 from torchmetrics.functional.regression.mean_absolute_error import mean_absolute_error
@@ -115,6 +116,7 @@ __all__ = [
     "pairwise_euclidean_distance",
     "pairwise_linear_similarity",
     "pairwise_manhattan_distance",
+    "pairwise_manhatten_distance",
     "pearson_corrcoef",
     "permutation_invariant_training",
     "pit",

--- a/torchmetrics/functional/__init__.py
+++ b/torchmetrics/functional/__init__.py
@@ -43,7 +43,7 @@ from torchmetrics.functional.image.ssim import ssim
 from torchmetrics.functional.pairwise.cosine import pairwise_cosine_similarity
 from torchmetrics.functional.pairwise.euclidean import pairwise_euclidean_distance
 from torchmetrics.functional.pairwise.linear import pairwise_linear_similarity
-from torchmetrics.functional.pairwise.manhatten import pairwise_manhatten_distance
+from torchmetrics.functional.pairwise.manhattan import pairwise_manhattan_distance
 from torchmetrics.functional.regression.cosine_similarity import cosine_similarity
 from torchmetrics.functional.regression.explained_variance import explained_variance
 from torchmetrics.functional.regression.mean_absolute_error import mean_absolute_error
@@ -114,7 +114,7 @@ __all__ = [
     "pairwise_cosine_similarity",
     "pairwise_euclidean_distance",
     "pairwise_linear_similarity",
-    "pairwise_manhatten_distance",
+    "pairwise_manhattan_distance",
     "pearson_corrcoef",
     "permutation_invariant_training",
     "pit",

--- a/torchmetrics/functional/pairwise/__init__.py
+++ b/torchmetrics/functional/pairwise/__init__.py
@@ -14,4 +14,4 @@
 from torchmetrics.functional.pairwise.cosine import pairwise_cosine_similarity  # noqa: F401
 from torchmetrics.functional.pairwise.euclidean import pairwise_euclidean_distance  # noqa: F401
 from torchmetrics.functional.pairwise.linear import pairwise_linear_similarity  # noqa: F401
-from torchmetrics.functional.pairwise.manhatten import pairwise_manhatten_distance  # noqa: F401
+from torchmetrics.functional.pairwise.manhattan import pairwise_manhattan_distance  # noqa: F401

--- a/torchmetrics/functional/pairwise/__init__.py
+++ b/torchmetrics/functional/pairwise/__init__.py
@@ -15,3 +15,4 @@ from torchmetrics.functional.pairwise.cosine import pairwise_cosine_similarity  
 from torchmetrics.functional.pairwise.euclidean import pairwise_euclidean_distance  # noqa: F401
 from torchmetrics.functional.pairwise.linear import pairwise_linear_similarity  # noqa: F401
 from torchmetrics.functional.pairwise.manhattan import pairwise_manhattan_distance  # noqa: F401
+from torchmetrics.functional.pairwise.manhatten import pairwise_manhatten_distance  # noqa: F401

--- a/torchmetrics/functional/pairwise/manhattan.py
+++ b/torchmetrics/functional/pairwise/manhattan.py
@@ -18,10 +18,10 @@ from torch import Tensor
 from torchmetrics.functional.pairwise.helpers import _check_input, _reduce_distance_matrix
 
 
-def _pairwise_manhatten_distance_update(
+def _pairwise_manhattan_distance_update(
     x: Tensor, y: Optional[Tensor] = None, zero_diagonal: Optional[bool] = None
 ) -> Tensor:
-    """Calculates the pairwise manhatten similarity matrix.
+    """Calculates the pairwise manhattan similarity matrix.
 
     Args:
         x: tensor of shape ``[N,d]``
@@ -36,11 +36,11 @@ def _pairwise_manhatten_distance_update(
     return distance
 
 
-def pairwise_manhatten_distance(
+def pairwise_manhattan_distance(
     x: Tensor, y: Optional[Tensor] = None, reduction: Optional[str] = None, zero_diagonal: Optional[bool] = None
 ) -> Tensor:
     r"""
-    Calculates pairwise manhatten distance:
+    Calculates pairwise manhattan distance:
 
     .. math::
         d_{man}(x,y) = ||x-y||_1 = \sum_{d=1}^D |x_d - y_d|
@@ -61,18 +61,18 @@ def pairwise_manhatten_distance(
 
     Example:
         >>> import torch
-        >>> from torchmetrics.functional import pairwise_manhatten_distance
+        >>> from torchmetrics.functional import pairwise_manhattan_distance
         >>> x = torch.tensor([[2, 3], [3, 5], [5, 8]], dtype=torch.float32)
         >>> y = torch.tensor([[1, 0], [2, 1]], dtype=torch.float32)
-        >>> pairwise_manhatten_distance(x, y)
+        >>> pairwise_manhattan_distance(x, y)
         tensor([[ 4.,  2.],
                 [ 7.,  5.],
                 [12., 10.]])
-        >>> pairwise_manhatten_distance(x)
+        >>> pairwise_manhattan_distance(x)
         tensor([[0., 3., 8.],
                 [3., 0., 5.],
                 [8., 5., 0.]])
 
     """
-    distance = _pairwise_manhatten_distance_update(x, y, zero_diagonal)
+    distance = _pairwise_manhattan_distance_update(x, y, zero_diagonal)
     return _reduce_distance_matrix(distance, reduction)

--- a/torchmetrics/functional/pairwise/manhatten.py
+++ b/torchmetrics/functional/pairwise/manhatten.py
@@ -1,0 +1,50 @@
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Optional
+from warnings import warn
+
+from torch import Tensor
+
+from torchmetrics.functional.pairwise.manhattan import pairwise_manhattan_distance
+
+
+def pairwise_manhatten_distance(
+    x: Tensor, y: Optional[Tensor] = None, reduction: Optional[str] = None, zero_diagonal: Optional[bool] = None
+) -> Tensor:
+    r"""
+    Calculates pairwise manhattan distance.
+
+    .. deprecated:: v0.7
+        Use :func:`torchmetrics.functional.pairwise_manhatten_distance`. Will be removed in v0.8.
+
+    Example:
+        >>> import torch
+        >>> x = torch.tensor([[2, 3], [3, 5], [5, 8]], dtype=torch.float32)
+        >>> y = torch.tensor([[1, 0], [2, 1]], dtype=torch.float32)
+        >>> pairwise_manhatten_distance(x, y)
+        tensor([[ 4.,  2.],
+                [ 7.,  5.],
+                [12., 10.]])
+        >>> pairwise_manhatten_distance(x)
+        tensor([[0., 3., 8.],
+                [3., 0., 5.],
+                [8., 5., 0.]])
+
+    """
+    warn(
+        "`pairwise_manhatten_distance` was renamed to `pairwise_manhattan_distance` in v0.7"
+        " and it will be removed in v0.8",
+        DeprecationWarning,
+    )
+    return pairwise_manhattan_distance(x, y, reduction, zero_diagonal)

--- a/torchmetrics/functional/pairwise/manhatten.py
+++ b/torchmetrics/functional/pairwise/manhatten.py
@@ -26,7 +26,7 @@ def pairwise_manhatten_distance(
     Calculates pairwise manhattan distance.
 
     .. deprecated:: v0.7
-        Use :func:`torchmetrics.functional.pairwise_manhatten_distance`. Will be removed in v0.8.
+        Use :func:`torchmetrics.functional.pairwise_manhattan_distance`. Will be removed in v0.8.
 
     Example:
         >>> import torch


### PR DESCRIPTION
## What does this PR do?

Renames instances of `manhatten` to `manhattan`. All I have done is a recursive find/replace and checked the result.

I'm pretty sure it's supposed to be manhattan, isn't it?? But it's so consistent it feels intentional, especially considering the combination of spellings here:
https://github.com/PyTorchLightning/metrics/blob/e6b6fb54f3b700d3e4b773953e9880f7f28e555a/tests/pairwise/test_pairwise_distance.py#L74
So, feel free to deny.

## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
