### PR TITLE
collections for PL back-compatibility

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -76,7 +76,7 @@ jobs:
         working-directory: ./docs
         run: |
           make clean
-          make html --debug --jobs 2 SPHINXOPTS="-W --keep-going" -b linkcheck
+          make html --debug SPHINXOPTS="-W --keep-going" -b linkcheck
 
       - name: Upload built docs
         uses: actions/upload-artifact@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 **Note: we move fast, but still we preserve 0.1 version (one feature release) back compatibility.**
 
 
-## [unreleased] - 2022-MM-DD
+## [0.7.0] - 2022-01-DD
 
 ### Added
 
@@ -18,111 +18,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `CHRFScore` ([#641](https://github.com/PyTorchLightning/metrics/pull/641))
   - `TranslationEditRate` ([#646](https://github.com/PyTorchLightning/metrics/pull/646))
   - `ExtendedEditDistance` ([#668](https://github.com/PyTorchLightning/metrics/pull/668))
-
-
 - Added `MultiScaleSSIM` into image metrics ([#679](https://github.com/PyTorchLightning/metrics/pull/679))
-
-
-- Added a default VSCode devcontainer configuration ([#621](https://github.com/PyTorchLightning/metrics/pull/621))
-
-
 - Added Signal to Distortion Ratio (`SDR`) to audio package ([#565](https://github.com/PyTorchLightning/metrics/pull/565))
-
-
 - Added `MinMaxMetric` to wrappers ([#556](https://github.com/PyTorchLightning/metrics/pull/556))
-
-
 - Added `ignore_index` to retrieval metrics ([#676](https://github.com/PyTorchLightning/metrics/pull/676))
-
-
 - Added support for multi references in `ROUGEScore` ([#680](https://github.com/PyTorchLightning/metrics/pull/680))
-
+- Added a default VSCode devcontainer configuration ([#621](https://github.com/PyTorchLightning/metrics/pull/621))
 
 ### Changed
 
 - Scalar metrics will now consistently have additional dimensions squeezed ([#622](https://github.com/PyTorchLightning/metrics/pull/622))
-
-
 - Metrics having third party dependencies removed from global import ([#463](https://github.com/PyTorchLightning/metrics/pull/463))
-
-
 - Untokenized for `BLEUScore` input stay consistent with all the other text metrics ([#640](https://github.com/PyTorchLightning/metrics/pull/640))
-
-
 - Arguments reordered for `TER`, `BLEUScore`, `SacreBLEUScore`, `CHRFScore` now expect input order as predictions first and target second ([#696](https://github.com/PyTorchLightning/metrics/pull/696))
-
-
 - Renamed `torchmetrics.collections` to `torchmetrics.metrics_collections` to avoid clashing with system's `collections` package ([#695](https://github.com/PyTorchLightning/metrics/pull/695))
-
-
 - Changed dtype of metric state from `torch.float` to `torch.long` in `ConfusionMatrix` to accommodate larger values ([#708](https://github.com/PyTorchLightning/metrics/issues/708))
-
+- Unify `preds`, `target` input argument's naming across all text metrics ([#723](https://github.com/PyTorchLightning/metrics/issues/723), [#727](https://github.com/PyTorchLightning/metrics/issues/727))
+  * `bert`, `bleu`, `chrf`, `sacre_bleu`, `wip`, `wil`, `cer`, `ter`, `wer`, `mer`, `rouge`, `squad`
 
 ### Deprecated
 
 - Renamed IoU -> Jaccard Index ([#662](https://github.com/PyTorchLightning/metrics/pull/662))
-
 - Renamed `WER` -> `WordErrorRate` and `wer` -> `word_error_rate` ([#714](https://github.com/PyTorchLightning/metrics/pull/714))
-
-
 - Renamed correlation coefficient classes: ([#710](https://github.com/PyTorchLightning/metrics/pull/710))
   * `MatthewsCorrcoef` -> `MatthewsCorrCoef`
   * `PearsonCorrcoef` -> `PearsonCorrCoef`
   * `SpearmanCorrcoef` -> `SpearmanCorrCoef`
-
 - Renamed audio SDR metrics: ([#711](https://github.com/PyTorchLightning/metrics/pull/711))
   * `functional.sdr` -> `functional.signal_distortion_ratio`
   * `functional.si_sdr` -> `functional.scale_invariant_signal_distortion_ratio`
   * `SDR` -> `SignalDistortionRatio`
   * `SI_SDR` -> `ScaleInvariantSignalDistortionRatio`
-
-
 - Renamed audio SNR metrics: ([#712](https://github.com/PyTorchLightning/metrics/pull/712))
   * `functional.snr` -> `functional.signal_distortion_ratio`
   * `functional.si_snr` -> `functional.scale_invariant_signal_noise_ratio`
   * `SNR` -> `SignalNoiseRatio`
   * `SI_SNR` -> `ScaleInvariantSignalNoiseRatio`
-
-
-- Renamed F-score metrics: ([#731](https://github.com/PyTorchLightning/metrics/pull/731))
+- Renamed F-score metrics: ([#731](https://github.com/PyTorchLightning/metrics/pull/731), [#740](https://github.com/PyTorchLightning/metrics/pull/740))
   * `torchmetrics.functional.f1` -> `torchmetrics.functional.f1_score`
   * `torchmetrics.F1` -> `torchmetrics.F1Score`
-
-
+  * `torchmetrics.functional.fbeta` -> `torchmetrics.functional.fbeta_score`
+  * `torchmetrics.FBeta` -> `torchmetrics.FBetaScore`
 - Renamed Hinge metric: ([#734](https://github.com/PyTorchLightning/metrics/pull/734))
   * `torchmetrics.functional.hinge` -> `torchmetrics.functional.hinge_loss`
   * `torchmetrics.Hinge` -> `torchmetrics.HingeLoss`
-
-- Renamed F-Beta metrics: ([#740](https://github.com/PyTorchLightning/metrics/pull/740))
-  * `torchmetrics.functional.fbeta` -> `torchmetrics.functional.fbeta_score`
-  * `torchmetrics.FBeta` -> `torchmetrics.FBetaScore`
-
-
-- Renamed image metrics ([#732](https://github.com/PyTorchLightning/metrics/pull/732))
+- Renamed image PSNR metrics ([#732](https://github.com/PyTorchLightning/metrics/pull/732))
   * `functional.psnr` -> `functional.peak_signal_noise_ratio`
   * `PSNR` -> `PeakSignalNoiseRatio`
-
-
-- Renamed PIT metric: ([#737](https://github.com/PyTorchLightning/metrics/pull/737))
+- Renamed image PIT metric: ([#737](https://github.com/PyTorchLightning/metrics/pull/737))
   * `torchmetrics.functional.pit` -> `torchmetrics.functional.permutation_invariant_training`
   * `torchmetrics.PIT` -> `torchmetrics.PermutationInvariantTraining`
-
-
-- Renamed SSIM metric: ([#747](https://github.com/PyTorchLightning/metrics/pull/747))
+- Renamed image SSIM metric: ([#747](https://github.com/PyTorchLightning/metrics/pull/747))
   * `torchmetrics.functional.ssim` -> `torchmetrics.functional.scale_invariant_signal_noise_ratio`
   * `torchmetrics.SSIM` -> `torchmetrics.StructuralSimilarityIndexMeasure`
-
 
 ### Removed
 
 - Removed `embedding_similarity` metric ([#638](https://github.com/PyTorchLightning/metrics/pull/638))
-
-
 - Removed argument `concatenate_texts` from `wer` metric ([#638](https://github.com/PyTorchLightning/metrics/pull/638))
-
-
 - Removed arguments `newline_sep` and `decimal_places` from `rouge` metric ([#638](https://github.com/PyTorchLightning/metrics/pull/638))
-
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Metrics having third party dependencies removed from global import ([#463](https://github.com/PyTorchLightning/metrics/pull/463))
 - Untokenized for `BLEUScore` input stay consistent with all the other text metrics ([#640](https://github.com/PyTorchLightning/metrics/pull/640))
 - Arguments reordered for `TER`, `BLEUScore`, `SacreBLEUScore`, `CHRFScore` now expect input order as predictions first and target second ([#696](https://github.com/PyTorchLightning/metrics/pull/696))
-- Renamed `torchmetrics.collections` to `torchmetrics.metrics_collections` to avoid clashing with system's `collections` package ([#695](https://github.com/PyTorchLightning/metrics/pull/695))
 - Changed dtype of metric state from `torch.float` to `torch.long` in `ConfusionMatrix` to accommodate larger values ([#708](https://github.com/PyTorchLightning/metrics/issues/708))
 - Unify `preds`, `target` input argument's naming across all text metrics ([#723](https://github.com/PyTorchLightning/metrics/issues/723), [#727](https://github.com/PyTorchLightning/metrics/issues/727))
   * `bert`, `bleu`, `chrf`, `sacre_bleu`, `wip`, `wil`, `cer`, `ter`, `wer`, `mer`, `rouge`, `squad`

--- a/tests/bases/test_collections.py
+++ b/tests/bases/test_collections.py
@@ -20,7 +20,7 @@ from tests.helpers import seed_all
 from tests.helpers.testers import DummyMetricDiff, DummyMetricSum
 from torchmetrics import Metric
 from torchmetrics.classification import Accuracy
-from torchmetrics.metric_collections import MetricCollection
+from torchmetrics.collections import MetricCollection
 
 seed_all(42)
 

--- a/torchmetrics/__about__.py
+++ b/torchmetrics/__about__.py
@@ -1,4 +1,4 @@
-__version__ = "0.7.0dev"
+__version__ = "0.7.0rc0"
 __author__ = "PyTorchLightning et al."
 __author_email__ = "name@pytorchlightning.ai"
 __license__ = "Apache-2.0"

--- a/torchmetrics/__init__.py
+++ b/torchmetrics/__init__.py
@@ -55,6 +55,7 @@ from torchmetrics.classification import (  # noqa: E402, F401
     Specificity,
     StatScores,
 )
+from torchmetrics.collections import MetricCollection  # noqa: E402
 from torchmetrics.image import (  # noqa: E402
     PSNR,
     SSIM,
@@ -63,7 +64,6 @@ from torchmetrics.image import (  # noqa: E402
     StructuralSimilarityIndexMeasure,
 )
 from torchmetrics.metric import Metric  # noqa: E402
-from torchmetrics.metric_collections import MetricCollection  # noqa: E402
 from torchmetrics.regression import (  # noqa: E402
     CosineSimilarity,
     ExplainedVariance,

--- a/torchmetrics/collections.py
+++ b/torchmetrics/collections.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import OrderedDict
 from copy import deepcopy
 from typing import Any, Dict, Hashable, Iterable, Optional, Sequence, Tuple, Union
 
@@ -21,6 +20,9 @@ from torch import nn
 
 from torchmetrics.metric import Metric
 from torchmetrics.utilities import rank_zero_warn
+
+# this is just a bypass for this module name collision with build-in one
+from torchmetrics.utilities.imports import OrderedDict
 
 
 class MetricCollection(nn.ModuleDict):

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -15,10 +15,9 @@ import functools
 import inspect
 import operator as op
 from abc import ABC, abstractmethod
-from collections.abc import Sequence
 from contextlib import contextmanager
 from copy import deepcopy
-from typing import Any, Callable, Dict, Generator, List, Optional, Union
+from typing import Any, Callable, Dict, Generator, List, Optional, Sequence, Union
 
 import torch
 from torch import Tensor

--- a/torchmetrics/utilities/imports.py
+++ b/torchmetrics/utilities/imports.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Import utilities."""
 import operator
+from collections import OrderedDict  # noqa: F401
 from importlib import import_module
 from importlib.util import find_spec
 from typing import Callable, Optional


### PR DESCRIPTION
## What does this PR do?

reverting `metric_collections` rename as it breaks back compatibility with PL v1.2

## Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
