### PR TITLE
Fix version incompatibility with pytest and pytest-doctestplus

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,6 @@
 coverage>5.2
 codecov>=2.1
-pytest>=6.0
+pytest==6.*
 pytest-cov>2.10
 # pytest-flake8
 pytest-doctestplus>=0.9.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,7 +3,7 @@ codecov>=2.1
 pytest>=6.0
 pytest-cov>2.10
 # pytest-flake8
-pytest-doctestplus
+pytest-doctestplus>=0.9.0
 check-manifest
 twine>=3.2
 mypy>=0.790


### PR DESCRIPTION
## What does this PR do?

Pytest == 7.0 with doctest-plus causes erros in Python 3.6.

## Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
