### PR TITLE
New argument `compute_on_cpu`

### DIFF
--- a/docs/source/pages/overview.rst
+++ b/docs/source/pages/overview.rst
@@ -351,9 +351,19 @@ A functional metric is differentiable if its corresponding modular metric is dif
 
 .. _Metric kwargs:
 
-*****************************
-Advanced distributed settings
-*****************************
+************************
+Advanced metric settings
+************************
+
+The following is a list of additional arguments that can be given to any metric class (in the ``**kwargs`` argument)
+that will alter how metric states are stored and synced.
+
+If you are running metrics on GPU and are encountering that you are running out of GPU VRAM then the following
+argument can help:
+
+- ``compute_on_cpu`` will automatically move the metric states to cpu after calling ``update``, making sure that
+  GPU memory is not filling up. The consequence will be that the ``compute`` method will be called on CPU instead
+  of GPU. Only applies to metric states that are lists.
 
 If you are running in a distributed environment, ``TorchMetrics`` will automatically take care of the distributed
 synchronization for you. However, the following three keyword arguments can be given to any metric class for

--- a/tests/image/test_inception.py
+++ b/tests/image/test_inception.py
@@ -104,11 +104,12 @@ class _ImgDataset(Dataset):
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="test is too slow without gpu")
 @pytest.mark.skipif(not _TORCH_FIDELITY_AVAILABLE, reason="test requires torch-fidelity")
-def test_compare_is(tmpdir):
+@pytest.mark.parametrize("compute_on_cpu", [True, False])
+def test_compare_is(tmpdir, compute_on_cpu):
     """check that the hole pipeline give the same result as torch-fidelity."""
     from torch_fidelity import calculate_metrics
 
-    metric = InceptionScore(splits=1).cuda()
+    metric = InceptionScore(splits=1, compute_on_cpu=compute_on_cpu).cuda()
 
     # Generate some synthetic data
     img1 = torch.randint(0, 255, (100, 3, 299, 299), dtype=torch.uint8)

--- a/tests/regression/test_pearson.py
+++ b/tests/regression/test_pearson.py
@@ -52,9 +52,9 @@ def _sk_pearsonr(preds, target):
 )
 class TestPearsonCorrcoef(MetricTester):
     atol = 1e-2
-
+    @pytest.mark.parametrize("compute_on_cpu", [True, False])
     @pytest.mark.parametrize("ddp", [True, False])
-    def test_pearson_corrcoef(self, preds, target, ddp):
+    def test_pearson_corrcoef(self, preds, target, compute_on_cpu, ddp):
         self.run_class_metric_test(
             ddp=ddp,
             preds=preds,
@@ -62,6 +62,7 @@ class TestPearsonCorrcoef(MetricTester):
             metric_class=PearsonCorrCoef,
             sk_metric=_sk_pearsonr,
             dist_sync_on_step=False,
+            metric_args={"compute_on_cpu": compute_on_cpu},
         )
 
     def test_pearson_corrcoef_functional(self, preds, target):

--- a/torchmetrics/detection/map.py
+++ b/torchmetrics/detection/map.py
@@ -696,14 +696,6 @@ class MeanAveragePrecision(Metric):
             - map_per_class: ``torch.Tensor`` (-1 if class metrics are disabled)
             - mar_100_per_class: ``torch.Tensor`` (-1 if class metrics are disabled)
         """
-
-        # move everything to CPU, as we are faster here
-        self.detection_boxes = [box.cpu() for box in self.detection_boxes]
-        self.detection_labels = [label.cpu() for label in self.detection_labels]
-        self.detection_scores = [score.cpu() for score in self.detection_scores]
-        self.groundtruth_boxes = [box.cpu() for box in self.groundtruth_boxes]
-        self.groundtruth_labels = [label.cpu() for label in self.groundtruth_labels]
-
         classes = self._get_classes()
         precisions, recalls = self._calculate(classes)
         map, mar = self._summarize_results(precisions, recalls)

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -245,6 +245,9 @@ class Metric(Module, ABC):
         self._to_sync = self.dist_sync_on_step  # type: ignore
         # skip restore cache operation from compute as cache is stored below.
         self._should_unsync = False
+        # skip computing on cpu for the batch
+        _temp_compute_on_cpu = self.compute_on_cpu
+        self.compute_on_cpu = False
 
         # save context before switch
         cache = {attr: getattr(self, attr) for attr in self._defaults}
@@ -262,6 +265,7 @@ class Metric(Module, ABC):
         self._should_unsync = True
         self._to_sync = True
         self._computed = None
+        self.compute_on_cpu = _temp_compute_on_cpu
 
         return self._forward_cache
 

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -299,7 +299,7 @@ class Metric(Module, ABC):
             self._update_called = True
             update(*args, **kwargs)
             if self.compute_on_cpu:
-                self._move_list_states()
+                self._move_list_states_to_cpu()
 
         return wrapped_func
 


### PR DESCRIPTION
## What does this PR do?

Rework of #851 
Fixes #848
General solution that allows *all* metrics where the metric state is a list to store the state on CPU instead of GPU through a new keyword argument `compute_on_cpu=True/False` (default `False`). This can beneficial in situations where the user do not have that much VRAM. Consequence of enabling this feature is that code in `compute` will be executed on CPU (code in `update` will still be executed on GPU).

Fixes #866
Related as the MAP metric currently moves all metric states to CPU for faster computations. As the issue points out this can overload the CPU. Feature in this PR essentially also fixes this by making it an option to move to CPU by setting `MeanAveragePrecision(compute_on_cpu=True)`.


## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
