### PR TITLE
Fix SDR compatibility with future PT 1.12

### DIFF
--- a/tests/audio/test_sdr.py
+++ b/tests/audio/test_sdr.py
@@ -27,7 +27,7 @@ from tests.helpers import seed_all
 from tests.helpers.testers import MetricTester
 from torchmetrics.audio import SignalDistortionRatio
 from torchmetrics.functional import signal_distortion_ratio
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_1_6, _TORCH_GREATER_EQUAL_1_8, _TORCH_LOWER_1_12
+from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_1_6, _TORCH_GREATER_EQUAL_1_8, _TORCH_LOWER_1_12_DEV
 
 seed_all(42)
 
@@ -155,13 +155,13 @@ def test_too_low_precision():
     preds = torch.tensor(data["preds"])
     target = torch.tensor(data["target"])
 
-    if _TORCH_GREATER_EQUAL_1_8 and _TORCH_LOWER_1_12:
+    if _TORCH_GREATER_EQUAL_1_8 and _TORCH_LOWER_1_12_DEV:
         with pytest.warns(
             UserWarning,
             match="Detected `nan` or `inf` value in computed metric, retrying computation in double precision",
         ):
             sdr_tm = signal_distortion_ratio(preds, target)
-    else:  # when pytorch < 1.8 or pytorch > 1.12, sdr doesn't have this problem
+    else:  # when pytorch < 1.8 or pytorch >= 1.12, sdr doesn't have this problem
         sdr_tm = signal_distortion_ratio(preds, target).double()
 
     # check equality with bss_eval_sources in every pytorch version
@@ -170,5 +170,5 @@ def test_too_low_precision():
         sdr_tm.mean(),
         torch.tensor(sdr_bss).mean(),
         rtol=0.0001,
-        atol=1e-4,
+        atol=1e-2,
     )

--- a/tests/audio/test_sdr.py
+++ b/tests/audio/test_sdr.py
@@ -162,7 +162,7 @@ def test_too_low_precision():
         ):
             sdr_tm = signal_distortion_ratio(preds, target)
     else:  # when pytorch < 1.8 or pytorch > 1.12, sdr doesn't have this problem
-        sdr_tm = signal_distortion_ratio(preds, target)
+        sdr_tm = signal_distortion_ratio(preds, target).double()
 
     # check equality with bss_eval_sources in every pytorch version
     sdr_bss, _, _, _ = bss_eval_sources(target.numpy(), preds.numpy(), False)

--- a/tests/audio/test_sdr.py
+++ b/tests/audio/test_sdr.py
@@ -157,7 +157,8 @@ def test_too_low_precision():
 
     if _TORCH_GREATER_EQUAL_1_8 and _TORCH_LOWER_1_12:
         with pytest.warns(
-            UserWarning, match="Detected `nan` or `inf` value in computed metric, retrying computation in double precision"
+            UserWarning,
+            match="Detected `nan` or `inf` value in computed metric, retrying computation in double precision",
         ):
             sdr_tm = signal_distortion_ratio(preds, target)
     else:  # when pytorch < 1.8 or pytorch > 1.12, sdr doesn't have this problem

--- a/torchmetrics/utilities/imports.py
+++ b/torchmetrics/utilities/imports.py
@@ -94,6 +94,7 @@ def _compare_version(package: str, op: Callable, version: str) -> Optional[bool]
 _TORCH_LOWER_1_4: Optional[bool] = _compare_version("torch", operator.lt, "1.4.0")
 _TORCH_LOWER_1_5: Optional[bool] = _compare_version("torch", operator.lt, "1.5.0")
 _TORCH_LOWER_1_6: Optional[bool] = _compare_version("torch", operator.lt, "1.6.0")
+_TORCH_LOWER_1_12: Optional[bool] = _compare_version("torch", operator.lt, "1.12.0")
 _TORCH_GREATER_EQUAL_1_6: Optional[bool] = _compare_version("torch", operator.ge, "1.6.0")
 _TORCH_GREATER_EQUAL_1_7: Optional[bool] = _compare_version("torch", operator.ge, "1.7.0")
 _TORCH_GREATER_EQUAL_1_8: Optional[bool] = _compare_version("torch", operator.ge, "1.8.0")

--- a/torchmetrics/utilities/imports.py
+++ b/torchmetrics/utilities/imports.py
@@ -94,7 +94,7 @@ def _compare_version(package: str, op: Callable, version: str) -> Optional[bool]
 _TORCH_LOWER_1_4: Optional[bool] = _compare_version("torch", operator.lt, "1.4.0")
 _TORCH_LOWER_1_5: Optional[bool] = _compare_version("torch", operator.lt, "1.5.0")
 _TORCH_LOWER_1_6: Optional[bool] = _compare_version("torch", operator.lt, "1.6.0")
-_TORCH_LOWER_1_12: Optional[bool] = _compare_version("torch", operator.lt, "1.12.0")
+_TORCH_LOWER_1_12_DEV: Optional[bool] = _compare_version("torch", operator.lt, "1.12.0.dev")
 _TORCH_GREATER_EQUAL_1_6: Optional[bool] = _compare_version("torch", operator.ge, "1.6.0")
 _TORCH_GREATER_EQUAL_1_7: Optional[bool] = _compare_version("torch", operator.ge, "1.7.0")
 _TORCH_GREATER_EQUAL_1_8: Optional[bool] = _compare_version("torch", operator.ge, "1.8.0")


### PR DESCRIPTION
## What does this PR do?

Fix the problem is disscussed in slack: SDR doesn't warn for low precision in PT 1.12

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
