### PR TITLE
Restructure of lightning logging docs

### DIFF
--- a/docs/source/pages/lightning.rst
+++ b/docs/source/pages/lightning.rst
@@ -9,17 +9,21 @@
 TorchMetrics in PyTorch Lightning
 #################################
 
-TorchMetrics was originaly created as part of `PyTorch Lightning <https://github.com/PyTorchLightning/pytorch-lightning>`_, a powerful deep learning research framework designed for scaling models without boilerplate.
+TorchMetrics was originally created as part of `PyTorch Lightning <https://github.com/PyTorchLightning/pytorch-lightning>`_, a powerful deep learning research
+framework designed for scaling models without boilerplate.
 
-..note::
+.. note::
 
     TorchMetrics always offers compatibility with the last 2 major PyTorch Lightning versions, but we recommend to always keep both frameworks
     up-to-date for the best experience.
 
 While TorchMetrics was built to be used with native PyTorch, using TorchMetrics with Lightning offers additional benefits:
 
-* Module metrics are automatically placed on the correct device when properly defined inside a LightningModule. This means that your data will always be placed on the same device as your metrics.
-* Native support for logging metrics in Lightning using `self.log <https://pytorch-lightning.readthedocs.io/en/stable/extensions/logging.html#logging-from-a-lightningmodule>`_ inside your LightningModule.
+* Module metrics are automatically placed on the correct device when properly defined inside a LightningModule.
+  This means that your data will always be placed on the same device as your metrics. No need to call `.to(device)` anymore!
+* Native support for logging metrics in Lightning using
+  `self.log <https://pytorch-lightning.readthedocs.io/en/stable/extensions/logging.html#logging-from-a-lightningmodule>`_ inside
+  your LightningModule.
 * The ``.reset()`` method of the metric will automatically be called at the end of an epoch.
 
 The example below shows how to use a metric in your `LightningModule <https://pytorch-lightning.readthedocs.io/en/stable/common/lightning_module.html>`_:
@@ -45,45 +49,19 @@ The example below shows how to use a metric in your `LightningModule <https://py
             # log epoch metric
             self.log('train_acc_epoch', self.accuracy)
 
-.. note::
-
-    ``self.log`` in Lightning only supports logging of *scalar-tensors*. While the vast majority of metrics in torchmetrics returns a scalar tensor, some metrics such as
-    :class:`~torchmetrics.ConfusionMatrix`, :class:`~torchmetrics.ROC`, :class:`~torchmetrics.MAP`, :class:`~torchmetrics.RougeScore` return outputs that are non-scalar
-    tensors (often dicts or list of tensors) and should therefore be dealt with separately. For info about the return type and shape please look at the documentation for
-    the ``compute`` method for each metric you want to log.
-
-.. note::
-
-    Modular metrics contain internal states that should belong to only one DataLoader. In case you are using multiple DataLoaders,
-    it is recommended to initialize a separate modular metric instances for each DataLoader and use them separately.
-
-    .. testcode:: python
-
-        class MyModule(LightningModule):
-
-            def __init__(self):
-                ...
-                self.val_acc = nn.ModuleList([torchmetrics.Accuracy() for _ in range(2)])
-
-            def val_dataloader(self):
-                return [DataLoader(...), DataLoader(...)]
-
-            def validation_step(self, batch, batch_idx, dataloader_idx):
-                x, y = batch
-                preds = self(x)
-                ...
-                self.val_acc[dataloader_idx](preds, y)
-                self.log('val_acc', self.val_acc[dataloader_idx])
-
+Metric logging in Lightning happens through the `self.log` or `self.log_dict` method. Both methods only supports logging of *scalar-tensors*.
+While the vast majority of metrics in torchmetrics returns a scalar tensor, some metrics such as :class:`~torchmetrics.ConfusionMatrix`, :class:`~torchmetrics.ROC`,
+:class:`~torchmetrics.MAP`, :class:`~torchmetrics.RougeScore` return outputs that are non-scalar tensors (often dicts or list of tensors) and should therefore be
+dealt with separately. For info about the return type and shape please look at the documentation for the ``compute`` method for each metric you want to log.
 
 ********************
 Logging TorchMetrics
 ********************
 
-When :class:`~torchmetrics.Metric` objects, which return a scalar tensor,  are logged directly in Lightning using the LightningModule `self.log <https://pytorch-lightning.readthedocs.io/en/stable/extensions/logging.html#logging-from-a-lightningmodule>`_ method. Lightning will log
-the metric based on ``on_step`` and ``on_epoch`` flags present in ``self.log(...)``.
-If ``on_epoch`` is True, the logger automatically logs the end of epoch metric value by calling
-``.compute()``.
+Logging metrics can be done in two ways: either logging the metric object directly or the computed metric values. When :class:`~torchmetrics.Metric` objects, which return a scalar tensor,
+are logged directly in Lightning using the LightningModule `self.log <https://pytorch-lightning.readthedocs.io/en/stable/extensions/logging.html#logging-from-a-lightningmodule>`_ method.
+Lightning will log the metric based on ``on_step`` and ``on_epoch`` flags present in ``self.log(...)``. If ``on_epoch`` is True, the logger automatically logs the end of epoch metric
+value by calling ``.compute()``.
 
 .. note::
 
@@ -118,72 +96,46 @@ If ``on_epoch`` is True, the logger automatically logs the end of epoch metric v
             self.valid_acc(logits, y)
             self.log('valid_acc', self.valid_acc, on_step=True, on_epoch=True)
 
-.. note::
+As an alternative to logging the metric object and letting Lightning take care of when to reset the metric etc. you can also manually log the output
+of the metrics.
 
-    The ``.reset()`` method of the metric will automatically be called at the end of an epoch within lightning only if you pass
-    the metric instance inside `self.log <https://pytorch-lightning.readthedocs.io/en/stable/extensions/logging.html#logging-from-a-lightningmodule>`_.
-    Also if you are calling ``.compute`` by yourself, you need to call the ``.reset()`` too.
+.. testcode:: python
 
-    .. testcode:: python
+    class MyModule(LightningModule):
 
-        class MyModule(LightningModule):
+        def __init__(self):
+            ...
+            self.train_acc = torchmetrics.Accuracy()
+            self.valid_acc = torchmetrics.Accuracy()
 
-            def __init__(self):
-                ...
-                self.train_acc = torchmetrics.Accuracy()
-                self.train_precision = torchmetrics.Precision()
+        def training_step(self, batch, batch_idx):
+            x, y = batch
+            preds = self(x)
+            ...
+            batch_value = self.train_acc(preds, y)
+            self.log('train_acc_step', batch_value)
 
-            def training_step(self, batch, batch_idx):
-                x, y = batch
-                preds = self(x)
-                ...
+        def training_epoch_end(self, outputs):
+            self.train_acc.reset()
 
-                # this will reset the metric automatically at the epoch end
-                self.train_acc(preds, y)
-                self.log('train_acc', self.train_acc, on_step=True, on_epoch=False)
+        def validation_step(self, batch, batch_idx):
+            logits = self(x)
+            ...
+            self.valid_acc.update(logits, y)
 
-                # this will not reset the metric automatically at the epoch end
-                precision = self.train_precision(preds, y)
-                self.log('train_precision', precision, on_step=True, on_epoch=False)
+        def validation_epoch_end(self, outputs):
+            self.log('valid_acc_epoch', self.valid_acc.compute())
+            self.valid_acc.reset()
 
-            def training_epoch_end(self, outputs):
-                # this will compute and reset the metric automatically at the epoch end
-                self.log('train_epoch_accuracy', self.training_acc)
-
-                # this will not reset the metric automatically at the epoch end so you
-                # need to call it yourself
-                mean_precision = self.precision.compute()
-                self.log('train_epoch_precision', mean_precision)
-                self.precision.reset()
-
-
-.. note::
-
-    If using metrics in data parallel mode (dp), the metric update/logging should be done
-    in the ``<mode>_step_end`` method (where ``<mode>`` is either ``training``, ``validation``
-    or ``test``). This is due to metric states else being destroyed after each forward pass,
-    leading to wrong accumulation. In practice do the following:
-
-    .. testcode:: python
-
-        class MyModule(LightningModule):
-
-            def training_step(self, batch, batch_idx):
-                data, target = batch
-                preds = self(data)
-                # ...
-                return {'loss': loss, 'preds': preds, 'target': target}
-
-            def training_step_end(self, outputs):
-                #update and log
-                self.metric(outputs['preds'], outputs['target'])
-                self.log('metric', self.metric)
+Note that logging metrics this ways will require you to manually reset the metrics at the end of the epoch yourself. In general we recommend logging
+the metric object to make sure that metrics are correctly computed and reset. Additionally, we highly recommend that the two ways of logging is not
+mixed as it can lead to wrong results.
 
 .. note::
 
     When using any Modular metric, calling ``self.metric(...)`` or ``self.metric.forward(...)`` serves the dual purpose of calling ``self.metric.update()``
-    on its input and simultaneously returning the metric value over the provided input. So if you are logging a metric *only* on epoch-level, it
-    is recommended to call ``self.metric.update()`` directly to avoid the extra computation.
+    on its input and simultaneously returning the metric value over the provided input. So if you are logging a metric *only* on epoch-level (as in the
+    example above), it is recommended to call ``self.metric.update()`` directly to avoid the extra computation.
 
     .. testcode:: python
 
@@ -199,4 +151,70 @@ If ``on_epoch`` is True, the logger automatically logs the end of epoch metric v
                 self.valid_acc.update(logits, y)
                 self.log('valid_acc', self.valid_acc, on_step=True, on_epoch=True)
 
-For more details see `Lightning Docs <https://pytorch-lightning.readthedocs.io/en/stable/extensions/logging.html#logging-from-a-lightningmodule>`_
+
+***************
+Common pitfalls
+***************
+
+The following contains a list of pitfalls to be aware of:
+
+* If using metrics in data parallel mode (dp), the metric update/logging should be done
+  in the ``<mode>_step_end`` method (where ``<mode>`` is either ``training``, ``validation``
+  or ``test``). This is due to metric states else being destroyed after each forward pass,
+  leading to wrong accumulation. In practice do the following:
+
+.. testcode:: python
+
+    class MyModule(LightningModule):
+
+        def training_step(self, batch, batch_idx):
+            data, target = batch
+            preds = self(data)
+            # ...
+            return {'loss': loss, 'preds': preds, 'target': target}
+
+        def training_step_end(self, outputs):
+            #update and log
+            self.metric(outputs['preds'], outputs['target'])
+            self.log('metric', self.metric)
+
+* Modular metrics contain internal states that should belong to only one DataLoader. In case you are using multiple DataLoaders,
+  it is recommended to initialize a separate modular metric instances for each DataLoader and use them separately. The same holds
+  for using seperate metrics for training, validation and testing.
+
+.. testcode:: python
+
+    class MyModule(LightningModule):
+
+        def __init__(self):
+            ...
+            self.val_acc = nn.ModuleList([torchmetrics.Accuracy() for _ in range(2)])
+
+        def val_dataloader(self):
+            return [DataLoader(...), DataLoader(...)]
+
+        def validation_step(self, batch, batch_idx, dataloader_idx):
+            x, y = batch
+            preds = self(x)
+            ...
+            self.val_acc[dataloader_idx](preds, y)
+            self.log('val_acc', self.val_acc[dataloader_idx])
+
+* Mixing the two logging methods by calling ``self.log("val", self.metric)`` in ``{training}/{val}/{test}_step`` method and
+  then calling ``self.log("val", self.metric.compute())`` in the corresponding ``{training}/{val}/{test}_epoch_end`` method.
+  Because the object is logged in the first case, Lightning will reset the metric before calling the second line leading to
+  errors or nonsense results.
+
+* Calling ``self.log("val", self.metric(preds, target))`` with the intention of logging the metric object. Because
+  ``self.metric(preds, target)`` corresponds to calling the forward method, this will return a tensor and not the
+  metric object. Such logging will be wrong in this case. Instead it is important to seperate into seperate lines:
+
+.. testcode:: python
+
+    def training_step(self, batch, batch_idx):
+        x, y = batch
+        preds = self(x)
+        ...
+        # log step metric
+        self.accuracy(preds, y)  # compute metrics
+        self.log('train_acc_step', self.accuracy)  # log metric object

--- a/docs/source/pages/lightning.rst
+++ b/docs/source/pages/lightning.rst
@@ -19,8 +19,8 @@ framework designed for scaling models without boilerplate.
 
 While TorchMetrics was built to be used with native PyTorch, using TorchMetrics with Lightning offers additional benefits:
 
-* Module metrics are automatically placed on the correct device when properly defined inside a LightningModule.
-  This means that your data will always be placed on the same device as your metrics. No need to call `.to(device)` anymore!
+* Modular metrics are automatically placed on the correct device when properly defined inside a LightningModule.
+  This means that your data will always be placed on the same device as your metrics. No need to call ``.to(device)`` anymore!
 * Native support for logging metrics in Lightning using
   `self.log <https://pytorch-lightning.readthedocs.io/en/stable/extensions/logging.html#logging-from-a-lightningmodule>`_ inside
   your LightningModule.
@@ -49,17 +49,17 @@ The example below shows how to use a metric in your `LightningModule <https://py
             # log epoch metric
             self.log('train_acc_epoch', self.accuracy)
 
-Metric logging in Lightning happens through the `self.log` or `self.log_dict` method. Both methods only supports logging of *scalar-tensors*.
+Metric logging in Lightning happens through the ``self.log`` or ``self.log_dict`` method. Both methods only support the logging of *scalar-tensors*.
 While the vast majority of metrics in torchmetrics returns a scalar tensor, some metrics such as :class:`~torchmetrics.ConfusionMatrix`, :class:`~torchmetrics.ROC`,
-:class:`~torchmetrics.MAP`, :class:`~torchmetrics.RougeScore` return outputs that are non-scalar tensors (often dicts or list of tensors) and should therefore be
+:class:`~torchmetrics.MeanAveragePrecision`, :class:`~torchmetrics.ROUGEScore` return outputs that are non-scalar tensors (often dicts or list of tensors) and should therefore be
 dealt with separately. For info about the return type and shape please look at the documentation for the ``compute`` method for each metric you want to log.
 
 ********************
 Logging TorchMetrics
 ********************
 
-Logging metrics can be done in two ways: either logging the metric object directly or the computed metric values. When :class:`~torchmetrics.Metric` objects, which return a scalar tensor,
-are logged directly in Lightning using the LightningModule `self.log <https://pytorch-lightning.readthedocs.io/en/stable/extensions/logging.html#logging-from-a-lightningmodule>`_ method.
+Logging metrics can be done in two ways: either logging the metric object directly or the computed metric values. When :class:`~torchmetrics.Metric` objects, which return a scalar tensor
+are logged directly in Lightning using the LightningModule `self.log <https://pytorch-lightning.readthedocs.io/en/stable/extensions/logging.html#logging-from-a-lightningmodule>`_ method,
 Lightning will log the metric based on ``on_step`` and ``on_epoch`` flags present in ``self.log(...)``. If ``on_epoch`` is True, the logger automatically logs the end of epoch metric
 value by calling ``.compute()``.
 
@@ -127,8 +127,8 @@ of the metrics.
             self.log('valid_acc_epoch', self.valid_acc.compute())
             self.valid_acc.reset()
 
-Note that logging metrics this ways will require you to manually reset the metrics at the end of the epoch yourself. In general we recommend logging
-the metric object to make sure that metrics are correctly computed and reset. Additionally, we highly recommend that the two ways of logging is not
+Note that logging metrics this way will require you to manually reset the metrics at the end of the epoch yourself. In general, we recommend logging
+the metric object to make sure that metrics are correctly computed and reset. Additionally, we highly recommend that the two ways of logging are not
 mixed as it can lead to wrong results.
 
 .. note::
@@ -153,15 +153,14 @@ mixed as it can lead to wrong results.
 
 
 ***************
-Common pitfalls
+Common Pitfalls
 ***************
 
 The following contains a list of pitfalls to be aware of:
 
 * If using metrics in data parallel mode (dp), the metric update/logging should be done
   in the ``<mode>_step_end`` method (where ``<mode>`` is either ``training``, ``validation``
-  or ``test``). This is due to metric states else being destroyed after each forward pass,
-  leading to wrong accumulation. In practice do the following:
+  or ``test``). This is because ``dp`` split the batches during the forward pass and metric states are destroyed after each forward pass, thus leading to wrong accumulation. In practice do the following:
 
 .. testcode:: python
 
@@ -174,7 +173,7 @@ The following contains a list of pitfalls to be aware of:
             return {'loss': loss, 'preds': preds, 'target': target}
 
         def training_step_end(self, outputs):
-            #update and log
+            # update and log
             self.metric(outputs['preds'], outputs['target'])
             self.log('metric', self.metric)
 


### PR DESCRIPTION
## What does this PR do?

Fixes #811
Restructuring of lightning logging docs. Currently consist of a bunch of notes which I tried to format into a more coherent text.
Added a "pitfalls" section with description of some common pitfalls.


## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
