### PR TITLE
Fix a typo in SMAPE doc

### DIFF
--- a/torchmetrics/functional/regression/symmetric_mape.py
+++ b/torchmetrics/functional/regression/symmetric_mape.py
@@ -68,7 +68,7 @@ def symmetric_mean_absolute_percentage_error(preds: Tensor, target: Tensor) -> T
     r"""
     Computes symmetric mean absolute percentage error (SMAPE_):
 
-    .. math:: \text{SMAPE} = \frac{2}{n}\sum_1^n\frac{max(|   y_i - \hat{y_i} |}{| y_i | + | \hat{y_i} |, \epsilon)}
+    .. math:: \text{SMAPE} = \frac{2}{n}\sum_1^n\frac{|   y_i - \hat{y_i} |}{max(| y_i | + | \hat{y_i} |, \epsilon)}
 
     Where :math:`y` is a tensor of target values, and :math:`\hat{y}` is a tensor of predictions.
 


### PR DESCRIPTION
## What does this PR do?

Fixes a typo about SMAPE formula which results in erroneously rendered docs here: https://torchmetrics.readthedocs.io/en/v0.7.3/references/functional.html#symmetric-mean-absolute-percentage-error-func

![image](https://user-images.githubusercontent.com/65476554/160989729-76a49823-dab1-408d-bd77-73684b02310e.png)

It should now look like 

![image](https://user-images.githubusercontent.com/65476554/160989902-d867ed4c-8506-4d63-87ce-65995aa5b5c6.png)



## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
