### PR TITLE
Skip HF-related tests if connection issues arise

### DIFF
--- a/tests/text/helpers.py
+++ b/tests/text/helpers.py
@@ -438,6 +438,11 @@ class TextTester(MetricTester):
 
 
 def skip_on_connection_issues(reason: str = "Unable to load checkpoints from HuggingFace `transformers`."):
+    """Wrapper which handles HF-related tests if they fail due to connection issues.
+
+    The tests run normally if no connection issue arises, and they're marked as skipped otherwise.
+    """
+
     def test_decorator(function: Callable, *args: Any, **kwargs: Any) -> Optional[Callable]:
         @wraps(function)
         def run_test(*args: Any, **kwargs: Any) -> Optional[Any]:

--- a/tests/text/helpers.py
+++ b/tests/text/helpers.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 import pickle
 import sys
-from functools import partial
-from typing import Any, Callable, Sequence, Union
+from functools import partial, wraps
+from typing import Any, Callable, Optional, Sequence, Union
 
 import pytest
 import torch
@@ -435,3 +435,17 @@ class TextTester(MetricTester):
         if metric.is_differentiable:
             # check for numerical correctness
             assert torch.autograd.gradcheck(partial(metric_functional, **metric_args), (preds[0], targets[0]))
+
+
+def skip_on_connection_issues(reason: str = "Unable to load checkpoints from HuggingFace `transformers`."):
+    def test_decorator(function: Callable, *args: Any, **kwargs: Any) -> Optional[Callable]:
+        @wraps(function)
+        def run_test(*args: Any, **kwargs: Any) -> Optional[Any]:
+            try:
+                return function(*args, **kwargs)
+            except OSError:
+                pytest.skip(reason)
+
+        return run_test
+
+    return test_decorator

--- a/tests/text/helpers.py
+++ b/tests/text/helpers.py
@@ -442,14 +442,18 @@ def skip_on_connection_issues(reason: str = "Unable to load checkpoints from Hug
 
     The tests run normally if no connection issue arises, and they're marked as skipped otherwise.
     """
+    _error_msg_start = "We couldn't connect to"
 
     def test_decorator(function: Callable, *args: Any, **kwargs: Any) -> Optional[Callable]:
         @wraps(function)
         def run_test(*args: Any, **kwargs: Any) -> Optional[Any]:
             try:
                 return function(*args, **kwargs)
-            except OSError:
-                pytest.skip(reason)
+            except OSError as e:
+                if _error_msg_start in str(e):
+                    pytest.skip(reason)
+                else:
+                    raise e
 
         return run_test
 

--- a/tests/text/helpers.py
+++ b/tests/text/helpers.py
@@ -449,11 +449,10 @@ def skip_on_connection_issues(reason: str = "Unable to load checkpoints from Hug
         def run_test(*args: Any, **kwargs: Any) -> Optional[Any]:
             try:
                 return function(*args, **kwargs)
-            except OSError as e:
-                if _error_msg_start in str(e):
-                    pytest.skip(reason)
-                else:
-                    raise e
+            except OSError as ex:
+                if _error_msg_start not in str(ex):
+                    raise ex
+                pytest.skip(reason)
 
         return run_test
 

--- a/tests/text/test_bertscore.py
+++ b/tests/text/test_bertscore.py
@@ -7,6 +7,7 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 
+from tests.text.helpers import skip_on_connection_issues
 from torchmetrics.functional.text.bert import bert_score as metrics_bert_score
 from torchmetrics.text.bert import BERTScore
 from torchmetrics.utilities.imports import _BERTSCORE_AVAILABLE
@@ -59,6 +60,7 @@ targets_batched = [targets[0:2], targets[2:]]
     [(preds, targets)],
 )
 @pytest.mark.skipif(not _BERTSCORE_AVAILABLE, reason="test requires bert_score")
+@skip_on_connection_issues()
 def test_score_fn(preds, targets):
     """Tests for functional."""
     original_score = original_bert_score(preds, targets, model_type=MODEL_NAME, num_layers=8, idf=False, batch_size=3)
@@ -77,6 +79,7 @@ def test_score_fn(preds, targets):
     [(preds, targets)],
 )
 @pytest.mark.skipif(not _BERTSCORE_AVAILABLE, reason="test requires bert_score")
+@skip_on_connection_issues()
 def test_score_fn_with_idf(preds, targets):
     """Tests for functional with IDF rescaling."""
     original_score = original_bert_score(preds, targets, model_type=MODEL_NAME, num_layers=12, idf=True, batch_size=3)
@@ -96,6 +99,7 @@ def test_score_fn_with_idf(preds, targets):
 )
 @pytest.mark.parametrize("device", ["cpu", "cuda", None])
 @pytest.mark.skipif(not _BERTSCORE_AVAILABLE, reason="test requires bert_score")
+@skip_on_connection_issues()
 def test_score_fn_all_layers(preds, targets, device):
     """Tests for functional and all layers."""
     if not torch.cuda.is_available() and device == "cuda":
@@ -119,6 +123,7 @@ def test_score_fn_all_layers(preds, targets, device):
     [(preds, targets)],
 )
 @pytest.mark.skipif(not _BERTSCORE_AVAILABLE, reason="test requires bert_score")
+@skip_on_connection_issues()
 def test_score_fn_all_layers_with_idf(preds, targets):
     """Tests for functional and all layers with IDF rescaling."""
     original_score = original_bert_score(preds, targets, model_type=MODEL_NAME, all_layers=True, idf=True, batch_size=3)
@@ -137,6 +142,7 @@ def test_score_fn_all_layers_with_idf(preds, targets):
     [(preds, targets)],
 )
 @pytest.mark.skipif(not _BERTSCORE_AVAILABLE, reason="test requires bert_score")
+@skip_on_connection_issues()
 def test_score_fn_all_layers_rescale_with_baseline(preds, targets):
     """Tests for functional with baseline rescaling."""
     original_score = original_bert_score(
@@ -171,6 +177,7 @@ def test_score_fn_all_layers_rescale_with_baseline(preds, targets):
     [(preds, targets)],
 )
 @pytest.mark.skipif(not _BERTSCORE_AVAILABLE, reason="test requires bert_score")
+@skip_on_connection_issues()
 def test_score_fn_rescale_with_baseline(preds, targets):
     """Tests for functional with baseline rescaling with all layers."""
     original_score = original_bert_score(
@@ -205,6 +212,7 @@ def test_score_fn_rescale_with_baseline(preds, targets):
     [(preds, targets)],
 )
 @pytest.mark.skipif(not _BERTSCORE_AVAILABLE, reason="test requires bert_score")
+@skip_on_connection_issues()
 def test_score(preds, targets):
     """Tests for metric."""
     original_score = original_bert_score(preds, targets, model_type=MODEL_NAME, num_layers=8, idf=False, batch_size=3)
@@ -223,6 +231,7 @@ def test_score(preds, targets):
     [(preds, targets)],
 )
 @pytest.mark.skipif(not _BERTSCORE_AVAILABLE, reason="test requires bert_score")
+@skip_on_connection_issues()
 def test_score_with_idf(preds, targets):
     """Tests for metric with IDF rescaling."""
     original_score = original_bert_score(preds, targets, model_type=MODEL_NAME, num_layers=8, idf=True, batch_size=3)
@@ -241,6 +250,7 @@ def test_score_with_idf(preds, targets):
     [(preds, targets)],
 )
 @pytest.mark.skipif(not _BERTSCORE_AVAILABLE, reason="test requires bert_score")
+@skip_on_connection_issues()
 def test_score_all_layers(preds, targets):
     """Tests for metric and all layers."""
     original_score = original_bert_score(
@@ -261,6 +271,7 @@ def test_score_all_layers(preds, targets):
     [(preds, targets)],
 )
 @pytest.mark.skipif(not _BERTSCORE_AVAILABLE, reason="test requires bert_score")
+@skip_on_connection_issues()
 def test_score_all_layers_with_idf(preds, targets):
     """Tests for metric and all layers with IDF rescaling."""
     original_score = original_bert_score(preds, targets, model_type=MODEL_NAME, all_layers=True, idf=True, batch_size=3)
@@ -279,6 +290,7 @@ def test_score_all_layers_with_idf(preds, targets):
     [(preds_batched, targets_batched)],
 )
 @pytest.mark.skipif(not _BERTSCORE_AVAILABLE, reason="test requires bert_score")
+@skip_on_connection_issues()
 def test_accumulation(preds, targets):
     """Tests for metric works with accumulation."""
     original_score = original_bert_score(
@@ -320,6 +332,7 @@ def _test_score_ddp_fn(rank, world_size, preds, targets):
     [(preds, targets)],
 )
 @pytest.mark.skipif(not (_BERTSCORE_AVAILABLE and dist.is_available()), reason="test requires bert_score")
+@skip_on_connection_issues()
 def test_score_ddp(preds, targets):
     """Tests for metric using DDP."""
     world_size = 2


### PR DESCRIPTION
## What does this PR do?

This PR proposes a hotfix for handling randomly failed HF-related tests. Part of #939.

**Context:**

Caching HF checkpoints doesn't work properly in CI for now. As a result, sometimes problems with loading models from the HF hub occur, which randomly fails some of our tests with the following error.

```python
except HTTPError:
>           raise EnvironmentError(
                "We couldn't connect to 'https://huggingface.co/' to load this model and it looks like "
                f"{pretrained_model_name_or_path} is not the path to a directory conaining a {configuration_file} "
                "file.\nCheckout your internet connection or see how to run the library in offline mode at "
                "'https://huggingface.co/docs/transformers/installation#offline-mode'."
            )
E           OSError: We couldn't connect to 'https://huggingface.co/' to load this model and it looks like <model_name> is not the path to a directory conaining a config.json file.
```

With the proposed wrapper, tests run normally if no connection issue is raised, and they're marked as skip otherwise.

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
