### PR TITLE
PSNR is higher the better.

### DIFF
--- a/torchmetrics/image/psnr.py
+++ b/torchmetrics/image/psnr.py
@@ -70,7 +70,7 @@ class PeakSignalNoiseRatio(Metric):
     """
     min_target: Tensor
     max_target: Tensor
-    higher_is_better = False
+    higher_is_better = True
 
     def __init__(
         self,


### PR DESCRIPTION
## What does this PR do?

Sometimes torchmetrics's metrics can be used as losses. In these cases, we want the design to check `metric.higher_is_beter` to confirm if they have to minimize or maximize the metric. This bug implies, this is not reliable.

Fixes #960

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Definitely, yes. I love this package.


Make sure you had fun coding 🙃
