### PR TITLE
Explicit cast to `uint8` when bool inputs passed to `argsort` in MAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed "Sort currently does not support bool dtype on CUDA" error in MAP for empty preds ([#983](https://github.com/PyTorchLightning/metrics/pull/983))
+
+
 - Fixed `BinnedPrecisionRecallCurve` when `thresholds` argument is not provided ([#968](https://github.com/PyTorchLightning/metrics/pull/968))
 
 

--- a/tests/detection/test_map.py
+++ b/tests/detection/test_map.py
@@ -58,7 +58,7 @@ _inputs = Input(
                 scores=torch.Tensor([0.699]),
                 labels=torch.IntTensor([5]),
             ),  # coco image id 133
-        ],
+        ], 
     ],
     target=[
         [
@@ -95,7 +95,7 @@ _inputs = Input(
                 boxes=torch.Tensor([[13.99, 2.87, 640.00, 421.52]]),
                 labels=torch.IntTensor([5]),
             ),  # coco image id 133
-        ],
+        ], 
     ],
 )
 
@@ -129,6 +129,27 @@ _inputs2 = Input(
                 boxes=torch.Tensor([]),
                 labels=torch.IntTensor([]),
             )
+        ],
+    ],
+)
+
+_inputs3 = Input(
+    preds = [
+        [
+            dict(
+                boxes = torch.tensor([]),
+                scores = torch.tensor([]),
+                labels = torch.tensor([])
+            ),
+        ],
+    ],
+    target=[
+        [
+            dict(
+                boxes=torch.tensor([[1., 2., 3., 4.]]),
+                scores=torch.tensor([0.8]),
+                labels=torch.tensor([1]),
+            ),
         ],
     ],
 )
@@ -283,7 +304,7 @@ def _move_to_gpu(input):
 
 @pytest.mark.skipif(_pytest_condition, reason="test requires that torchvision=>0.8.0 is installed")
 @pytest.mark.skipif(_gpu_test_condition, reason="test requires CUDA availability")
-@pytest.mark.parametrize("inputs", [_inputs, _inputs2])
+@pytest.mark.parametrize("inputs", [_inputs, _inputs2, _inputs3])
 def test_map_gpu(inputs):
     """Test predictions on single gpu."""
     metric = MeanAveragePrecision()

--- a/tests/detection/test_map.py
+++ b/tests/detection/test_map.py
@@ -58,7 +58,7 @@ _inputs = Input(
                 scores=torch.Tensor([0.699]),
                 labels=torch.IntTensor([5]),
             ),  # coco image id 133
-        ], 
+        ],
     ],
     target=[
         [
@@ -95,7 +95,7 @@ _inputs = Input(
                 boxes=torch.Tensor([[13.99, 2.87, 640.00, 421.52]]),
                 labels=torch.IntTensor([5]),
             ),  # coco image id 133
-        ], 
+        ],
     ],
 )
 

--- a/torchmetrics/detection/mean_ap.py
+++ b/torchmetrics/detection/mean_ap.py
@@ -695,11 +695,9 @@ class MeanAveragePrecision(Metric):
         # different sorting method generates slightly different results.
         # mergesort is used to be consistent as Matlab implementation.
         # Sort in PyTorch does not support bool types on CUDA (yet, 1.11.0)
-        if det_scores.is_cuda and det_scores.dtype is torch.bool:
-            # Explicitly cast to uint8 to avoid error for bool inputs on CUDA to argsort
-            inds = torch.argsort(det_scores.to(torch.uint8), descending=True)
-        else:
-            inds = torch.argsort(det_scores, descending=True)
+        dtype = torch.uint8 if det_scores.is_cuda and det_scores.dtype is torch.bool else det_scores.dtype
+        # Explicitly cast to uint8 to avoid error for bool inputs on CUDA to argsort
+        inds = torch.argsort(det_scores.to(dtype), descending=True)
         det_scores_sorted = det_scores[inds]
 
         det_matches = torch.cat([e["dtMatches"][:, :max_det] for e in img_eval_cls_bbox], axis=1)[:, inds]

--- a/torchmetrics/detection/mean_ap.py
+++ b/torchmetrics/detection/mean_ap.py
@@ -694,7 +694,12 @@ class MeanAveragePrecision(Metric):
 
         # different sorting method generates slightly different results.
         # mergesort is used to be consistent as Matlab implementation.
-        inds = torch.argsort(det_scores, descending=True)
+        # Sort in PyTorch does not support bool types on CUDA (yet, 1.11.0)
+        if det_scores.is_cuda and det_scores.dtype is torch.bool:
+            # Explicitly cast to uint8 to avoid error for bool inputs on CUDA to argsort
+            inds = torch.argsort(det_scores.to(torch.uint8), descending=True)
+        else:
+            inds = torch.argsort(det_scores, descending=True)
         det_scores_sorted = det_scores[inds]
 
         det_matches = torch.cat([e["dtMatches"][:, :max_det] for e in img_eval_cls_bbox], axis=1)[:, inds]


### PR DESCRIPTION
## What does this PR do?

Fixes #981 

I can confirm that this is a regression from release 0.7.2, IMO: an explicit cast from `torch.bool` to `torch.uint8` (on CUDA only) while applying `torch.argsort` should fix this. Looks like PyTorch doesn't support sorting for boolean dtypes on CUDA devices:

```cpp
// FIXME: remove this check once cub sort supports bool
TORCH_CHECK(self_dtype != ScalarType::Bool,
  "Sort currently does not support bool dtype on CUDA.");
```
https://github.com/pytorch/pytorch/blob/1a7e43be141ce01469d7605075cb1008bf19abd7/aten/src/ATen/native/cuda/Sort.cpp#L80

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
