### PR TITLE
More robust metric state comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed non-empty state dict for a few metrics ([#1012](https://github.com/PyTorchLightning/metrics/pull/1012))
 
+- Fixed bug when comparing states while finding compute groups ([#1022](https://github.com/PyTorchLightning/metrics/pull/1022))
+
 
 ## [0.8.2] - 2022-05-06
 

--- a/torchmetrics/collections.py
+++ b/torchmetrics/collections.py
@@ -20,7 +20,7 @@ from torch.nn import Module, ModuleDict
 
 from torchmetrics.metric import Metric
 from torchmetrics.utilities import rank_zero_warn
-from torchmetrics.utilities.data import _flatten_dict
+from torchmetrics.utilities.data import _flatten_dict, allclose
 
 # this is just a bypass for this module name collision with build-in one
 from torchmetrics.utilities.imports import OrderedDict
@@ -231,10 +231,10 @@ class MetricCollection(ModuleDict):
                 return False
 
             if isinstance(state1, Tensor) and isinstance(state2, Tensor):
-                return state1.shape == state2.shape and torch.allclose(state1, state2)
+                return state1.shape == state2.shape and allclose(state1, state2)
 
             if isinstance(state1, list) and isinstance(state2, list):
-                return all(s1.shape == s2.shape and torch.allclose(s1, s2) for s1, s2 in zip(state1, state2))
+                return all(s1.shape == s2.shape and allclose(s1, s2) for s1, s2 in zip(state1, state2))
 
         return True
 

--- a/torchmetrics/utilities/data.py
+++ b/torchmetrics/utilities/data.py
@@ -248,3 +248,10 @@ def _bincount(x: Tensor, minlength: Optional[int] = None) -> Tensor:
         return output
     else:
         return torch.bincount(x, minlength=minlength)
+
+
+def allclose(tensor1: Tensor, tensor2: Tensor) -> bool:
+    """Wrapper of torch.allclose that is robust towards dtype difference."""
+    if tensor1.dtype != tensor2.dtype:
+        tensor2 = tensor2.to(dtype=tensor1.dtype)
+    return torch.allclose(tensor1, tensor2)


### PR DESCRIPTION
## What does this PR do?

Fixes bug found in discussion https://github.com/PyTorchLightning/metrics/discussions/1016
When searching for compute groups in metric collection we need to compare the states between metrics. `torch.allclose` is not robust to difference in `dtype` such as `np.allclose` (see issue https://github.com/pytorch/pytorch/issues/55356). PR makes this comparison more robust.


## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
