### PR TITLE
Double support for stat score metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed non-empty state dict for a few metrics ([#1012](https://github.com/PyTorchLightning/metrics/pull/1012))
 
+- Fixed `torch.double` support in stat score metrics ([#1023](https://github.com/PyTorchLightning/metrics/pull/1023))
+
+
 
 ## [0.8.2] - 2022-05-06
 

--- a/tests/classification/test_stat_scores.py
+++ b/tests/classification/test_stat_scores.py
@@ -173,10 +173,12 @@ class TestStatScores(MetricTester):
     # DDP tests temporarily disabled due to hanging issues
     @pytest.mark.parametrize("ddp", [False])
     @pytest.mark.parametrize("dist_sync_on_step", [True, False])
+    @pytest.mark.parametrize("dtype", [torch.float, torch.double])
     def test_stat_scores_class(
         self,
         ddp: bool,
         dist_sync_on_step: bool,
+        dtype: torch.dtype,
         sk_fn: Callable,
         preds: Tensor,
         target: Tensor,
@@ -190,6 +192,11 @@ class TestStatScores(MetricTester):
     ):
         if ignore_index is not None and preds.ndim == 2:
             pytest.skip("Skipping ignore_index test with binary inputs.")
+
+        if preds.is_floating_point():
+            preds = preds.to(dtype)
+        if target.is_floating_point():
+            target = target.to(dtype)
 
         self.run_class_metric_test(
             ddp=ddp,


### PR DESCRIPTION
## What does this PR do?

Fixes #1018
Note to self: we should standardize testing with `double` in upcoming classification refactor.

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
