### PR TITLE
fixed small typo

### DIFF
--- a/docs/source/pages/overview.rst
+++ b/docs/source/pages/overview.rst
@@ -96,8 +96,8 @@ be moved to the same device as the input of the metric:
     print(out.device) # cuda:0
 
 However, when **properly defined** inside a :class:`~torch.nn.Module` or
-:class:`~pytorch_lightning.core.lightning.LightningModule` the metric will be be automatically move
-to the same device as the the module when using ``.to(device)``.  Being
+:class:`~pytorch_lightning.core.lightning.LightningModule` the metric will be automatically moved
+to the same device as the module when using ``.to(device)``.  Being
 **properly defined** means that the metric is correctly identified as a child module of the
 model (check ``.children()`` attribute of the model). Therefore, metrics cannot be placed
 in native python ``list`` and ``dict``, as they will not be correctly identified


### PR DESCRIPTION
`be be automatically move to the same device as the the module`
to
`be automatically moved to the same device as the module`

## What does this PR do?

Fixes small typo in documentation

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
