### PR TITLE
fix deterministic for Pytorch<1.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.17.2
-torch>=1.8.0
+torch>=1.3.1
 packaging
 typing-extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.17.2
-torch>=1.3.1
+torch>=1.8.0
 packaging

--- a/torchmetrics/utilities/data.py
+++ b/torchmetrics/utilities/data.py
@@ -16,12 +16,15 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Union
 import torch
 from torch import Tensor, tensor
 
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_1_8
+from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_1_7, _TORCH_GREATER_EQUAL_1_8
 
 if _TORCH_GREATER_EQUAL_1_8:
     deterministic = torch.are_deterministic_algorithms_enabled
-else:
+elif _TORCH_GREATER_EQUAL_1_7:
     deterministic = torch.is_deterministic
+else:
+    # Assume for older versions that computations need to be deterministic
+    deterministic = lambda: True
 
 METRIC_EPS = 1e-6
 

--- a/torchmetrics/utilities/data.py
+++ b/torchmetrics/utilities/data.py
@@ -16,15 +16,16 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Union
 import torch
 from torch import Tensor, tensor
 
-from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_1_7, _TORCH_GREATER_EQUAL_1_8
+from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_1_6, _TORCH_GREATER_EQUAL_1_7, _TORCH_GREATER_EQUAL_1_8
 
 if _TORCH_GREATER_EQUAL_1_8:
     deterministic = torch.are_deterministic_algorithms_enabled
 elif _TORCH_GREATER_EQUAL_1_7:
     deterministic = torch.is_deterministic
+elif _TORCH_GREATER_EQUAL_1_6:
+    deterministic = torch._is_deterministic
 else:
-    # Assume for older versions that computations need to be deterministic
-    deterministic = lambda: True
+    deterministic = lambda: False
 
 METRIC_EPS = 1e-6
 

--- a/torchmetrics/utilities/data.py
+++ b/torchmetrics/utilities/data.py
@@ -25,8 +25,10 @@ elif _TORCH_GREATER_EQUAL_1_7:
 elif _TORCH_GREATER_EQUAL_1_6:
     deterministic = torch._is_deterministic
 else:
+
     def deterministic() -> bool:
         return True
+
 
 METRIC_EPS = 1e-6
 

--- a/torchmetrics/utilities/data.py
+++ b/torchmetrics/utilities/data.py
@@ -25,7 +25,8 @@ elif _TORCH_GREATER_EQUAL_1_7:
 elif _TORCH_GREATER_EQUAL_1_6:
     deterministic = torch._is_deterministic
 else:
-    deterministic = lambda: False
+    def deterministic() -> bool:
+        return True
 
 METRIC_EPS = 1e-6
 

--- a/torchmetrics/utilities/data.py
+++ b/torchmetrics/utilities/data.py
@@ -17,6 +17,7 @@ import torch
 from torch import Tensor, tensor
 
 from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_1_8
+
 if _TORCH_GREATER_EQUAL_1_8:
     deterministic = torch.are_deterministic_algorithms_enabled
 else:

--- a/torchmetrics/utilities/data.py
+++ b/torchmetrics/utilities/data.py
@@ -16,6 +16,12 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Union
 import torch
 from torch import Tensor, tensor
 
+from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_1_8
+if _TORCH_GREATER_EQUAL_1_8:
+    deterministic = torch.are_deterministic_algorithms_enabled
+else:
+    deterministic = torch.is_deterministic
+
 METRIC_EPS = 1e-6
 
 
@@ -239,7 +245,7 @@ def _bincount(x: Tensor, minlength: Optional[int] = None) -> Tensor:
     Returns:
         Number of occurrences for each unique element in x
     """
-    if x.is_cuda and torch.are_deterministic_algorithms_enabled():
+    if x.is_cuda and deterministic():
         if minlength is None:
             minlength = len(torch.unique(x))
         output = torch.zeros(minlength, device=x.device, dtype=torch.long)


### PR DESCRIPTION
In `requirements.txt` you depend on torch>=1.3.1 but while trying to use torchmetrics with torch1.4 I encountered an error in https://github.com/PyTorchLightning/metrics/blob/master/torchmetrics/utilities/data.py#L242 because `are_deterministic_algorithms_enabled` function is only available for torch>=1.8

## What does this PR do?

Fixes #1034 

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
