### PR TITLE
Fixed default value for mdmc_average in Accuracy as per documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed case where `KLDivergence` could output `Nan` ([#1030](https://github.com/PyTorchLightning/metrics/pull/1030))
 
 
+- Fixed default value for `mdmc_average` in `Accuracy` ([#1036](https://github.com/PyTorchLightning/metrics/pull/1036]))
+
+
 ## [0.8.2] - 2022-05-06
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed case where `KLDivergence` could output `Nan` ([#1030](https://github.com/PyTorchLightning/metrics/pull/1030))
 
 
-- Fixed default value for `mdmc_average` in `Accuracy` ([#1036](https://github.com/PyTorchLightning/metrics/pull/1036]))
+- Fixed default value for `mdmc_average` in `Accuracy` ([#1036](https://github.com/PyTorchLightning/metrics/pull/1036))
 
 
 ## [0.8.2] - 2022-05-06

--- a/tests/classification/test_accuracy.py
+++ b/tests/classification/test_accuracy.py
@@ -58,33 +58,33 @@ def _sk_accuracy(preds, target, subset_accuracy):
 
 
 @pytest.mark.parametrize(
-    "preds, target, subset_accuracy",
+    "preds, target, subset_accuracy, mdmc_average",
     [
-        (_input_binary_logits.preds, _input_binary_logits.target, False),
-        (_input_binary_prob.preds, _input_binary_prob.target, False),
-        (_input_binary.preds, _input_binary.target, False),
-        (_input_mlb_prob.preds, _input_mlb_prob.target, True),
-        (_input_mlb_logits.preds, _input_mlb_logits.target, False),
-        (_input_mlb_prob.preds, _input_mlb_prob.target, False),
-        (_input_mlb.preds, _input_mlb.target, True),
-        (_input_mlb.preds, _input_mlb.target, False),
-        (_input_mcls_prob.preds, _input_mcls_prob.target, False),
-        (_input_mcls_logits.preds, _input_mcls_logits.target, False),
-        (_input_mcls.preds, _input_mcls.target, False),
-        (_input_mdmc_prob.preds, _input_mdmc_prob.target, False),
-        (_input_mdmc_prob.preds, _input_mdmc_prob.target, True),
-        (_input_mdmc.preds, _input_mdmc.target, False),
-        (_input_mdmc.preds, _input_mdmc.target, True),
-        (_input_mlmd_prob.preds, _input_mlmd_prob.target, True),
-        (_input_mlmd_prob.preds, _input_mlmd_prob.target, False),
-        (_input_mlmd.preds, _input_mlmd.target, True),
-        (_input_mlmd.preds, _input_mlmd.target, False),
+        (_input_binary_logits.preds, _input_binary_logits.target, False, None),
+        (_input_binary_prob.preds, _input_binary_prob.target, False, None),
+        (_input_binary.preds, _input_binary.target, False, None),
+        (_input_mlb_prob.preds, _input_mlb_prob.target, True, None),
+        (_input_mlb_logits.preds, _input_mlb_logits.target, False, None),
+        (_input_mlb_prob.preds, _input_mlb_prob.target, False, None),
+        (_input_mlb.preds, _input_mlb.target, True, None),
+        (_input_mlb.preds, _input_mlb.target, False, "global"),
+        (_input_mcls_prob.preds, _input_mcls_prob.target, False, None),
+        (_input_mcls_logits.preds, _input_mcls_logits.target, False, None),
+        (_input_mcls.preds, _input_mcls.target, False, None),
+        (_input_mdmc_prob.preds, _input_mdmc_prob.target, False, "global"),
+        (_input_mdmc_prob.preds, _input_mdmc_prob.target, True, None),
+        (_input_mdmc.preds, _input_mdmc.target, False, "global"),
+        (_input_mdmc.preds, _input_mdmc.target, True, None),
+        (_input_mlmd_prob.preds, _input_mlmd_prob.target, True, None),
+        (_input_mlmd_prob.preds, _input_mlmd_prob.target, False, None),
+        (_input_mlmd.preds, _input_mlmd.target, True, None),
+        (_input_mlmd.preds, _input_mlmd.target, False, "global"),
     ],
 )
 class TestAccuracies(MetricTester):
     @pytest.mark.parametrize("ddp", [False, True])
     @pytest.mark.parametrize("dist_sync_on_step", [False, True])
-    def test_accuracy_class(self, ddp, dist_sync_on_step, preds, target, subset_accuracy):
+    def test_accuracy_class(self, ddp, dist_sync_on_step, preds, target, subset_accuracy, mdmc_average):
         self.run_class_metric_test(
             ddp=ddp,
             preds=preds,
@@ -92,10 +92,10 @@ class TestAccuracies(MetricTester):
             metric_class=Accuracy,
             sk_metric=partial(_sk_accuracy, subset_accuracy=subset_accuracy),
             dist_sync_on_step=dist_sync_on_step,
-            metric_args={"threshold": THRESHOLD, "subset_accuracy": subset_accuracy},
+            metric_args={"threshold": THRESHOLD, "subset_accuracy": subset_accuracy, "mdmc_average": mdmc_average},
         )
 
-    def test_accuracy_fn(self, preds, target, subset_accuracy):
+    def test_accuracy_fn(self, preds, target, subset_accuracy, mdmc_average):
         self.run_functional_metric_test(
             preds,
             target,
@@ -104,13 +104,13 @@ class TestAccuracies(MetricTester):
             metric_args={"threshold": THRESHOLD, "subset_accuracy": subset_accuracy},
         )
 
-    def test_accuracy_differentiability(self, preds, target, subset_accuracy):
+    def test_accuracy_differentiability(self, preds, target, subset_accuracy, mdmc_average):
         self.run_differentiability_test(
             preds=preds,
             target=target,
             metric_module=Accuracy,
             metric_functional=accuracy,
-            metric_args={"threshold": THRESHOLD, "subset_accuracy": subset_accuracy},
+            metric_args={"threshold": THRESHOLD, "subset_accuracy": subset_accuracy, "mdmc_average": mdmc_average},
         )
 
 
@@ -180,7 +180,7 @@ _multidim_multiclass_logits_with_neg_tgt = Input(
     ],
 )
 def test_topk_accuracy(preds, target, exp_result, k, subset_accuracy):
-    topk = Accuracy(top_k=k, subset_accuracy=subset_accuracy)
+    topk = Accuracy(top_k=k, subset_accuracy=subset_accuracy, mdmc_average="global")
 
     for batch in range(preds.shape[0]):
         topk(preds[batch], target[batch])

--- a/torchmetrics/classification/accuracy.py
+++ b/torchmetrics/classification/accuracy.py
@@ -165,7 +165,7 @@ class Accuracy(StatScores):
         threshold: float = 0.5,
         num_classes: Optional[int] = None,
         average: str = "micro",
-        mdmc_average: Optional[str] = "global",
+        mdmc_average: Optional[str] = None,
         ignore_index: Optional[int] = None,
         top_k: Optional[int] = None,
         multiclass: Optional[bool] = None,


### PR DESCRIPTION
## What does this PR do?
This PR fixes the default value in argument for mdmc_average from `"global"` to `None` as per the documentation of [Accuracy](https://github.com/PyTorchLightning/metrics/blob/master/torchmetrics/classification/accuracy.py#L81). This is also supported by the default value of mdmc_average in the documentation and code for [F1Score](https://github.com/PyTorchLightning/metrics/blob/master/torchmetrics/classification/f_beta.py#L255), [Precision](https://github.com/PyTorchLightning/metrics/blob/master/torchmetrics/classification/precision_recall.py#L120) and [Recall](https://github.com/PyTorchLightning/metrics/blob/master/torchmetrics/classification/precision_recall.py#L255).

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
