### PR TITLE
Use PyTorch's `any` implementation

### DIFF
--- a/torchmetrics/aggregation.py
+++ b/torchmetrics/aggregation.py
@@ -69,7 +69,7 @@ class BaseAggregator(Metric):
             x = torch.as_tensor(x, dtype=torch.float32, device=self.device)
 
         nans = torch.isnan(x)
-        if nans.any().item():
+        if nans.any():
             if self.nan_strategy == "error":
                 raise RuntimeError("Encounted `nan` values in tensor")
             if self.nan_strategy == "warn":

--- a/torchmetrics/aggregation.py
+++ b/torchmetrics/aggregation.py
@@ -69,7 +69,7 @@ class BaseAggregator(Metric):
             x = torch.as_tensor(x, dtype=torch.float32, device=self.device)
 
         nans = torch.isnan(x)
-        if any(nans.flatten()):
+        if nans.any().item():
             if self.nan_strategy == "error":
                 raise RuntimeError("Encounted `nan` values in tensor")
             if self.nan_strategy == "warn":


### PR DESCRIPTION
Python's `any` is much slower than PyTorch's `any` (especially if the data lives on the GPU and you can avoid unnecessary GPU -> CPU copy of `nans`), so this will be much faster.
