### PR TITLE
Better error message on wrong device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--
+- Added specific runtime error when metric object is on wrong device (#1056(https://github.com/PyTorchLightning/metrics/pull/1056))
 
 -
 

--- a/tests/bases/test_metric.py
+++ b/tests/bases/test_metric.py
@@ -25,6 +25,7 @@ from torch.nn import Module
 
 from tests.helpers import seed_all
 from tests.helpers.testers import DummyListMetric, DummyMetric, DummyMetricMultiOutput, DummyMetricSum
+from torchmetrics import PearsonCorrCoef
 from torchmetrics.utilities.imports import _TORCH_LOWER_1_6
 
 seed_all(42)
@@ -423,3 +424,14 @@ def test_warning_on_not_set_full_state_update(metric_class):
         match="Torchmetrics v0.9 introduced a new argument class property called.*",
     ):
         UnsetProperty()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires gpu")
+def test_specific_error_on_wrong_device():
+    metric = PearsonCorrCoef()
+    preds = torch.tensor(range(10), device="cuda", dtype=torch.float)
+    target = torch.tensor(range(10), device="cuda", dtype=torch.float)
+    with pytest.raises(
+        RuntimeError, match="This could be due to the metric class not being on the same device as input"
+    ):
+        _ = metric(preds, target)

--- a/tests/bases/test_metric.py
+++ b/tests/bases/test_metric.py
@@ -25,8 +25,8 @@ from torch.nn import Module
 
 from tests.helpers import seed_all
 from tests.helpers.testers import DummyListMetric, DummyMetric, DummyMetricMultiOutput, DummyMetricSum
-from torchmetrics import PearsonCorrCoef
 from tests.helpers.utilities import no_warning_call
+from torchmetrics import PearsonCorrCoef
 from torchmetrics.utilities.imports import _TORCH_LOWER_1_6
 
 seed_all(42)

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import functools
 import inspect
-import traceback
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from copy import deepcopy
@@ -382,13 +381,12 @@ class Metric(Module, ABC):
                     update(*args, **kwargs)
                 except RuntimeError as err:
                     if "Expected all tensors to be on" in str(err):
-                        traceback.print_exc()
                         raise RuntimeError(
                             f"{str(err)}. \n"
                             "This could be due to the metric class not being on the same device as input.\n"
                             "Instead of `metric=Metric()` try to do `metric=Metric().to(device)` where"
                             " device corresponds to the device of the input."
-                        )
+                        ) from err
                     raise err
 
             if self.compute_on_cpu:

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -383,8 +383,8 @@ class Metric(Module, ABC):
                 except RuntimeError as err:
                     if "Expected all tensors to be on" in str(err):
                         raise RuntimeError(
-                            f"{str(err)}."
-                            "Encountered different devices in metric calculation."
+                            "Encountered different devices in metric calculation"
+                            " (see stacktrace for details)."
                             "This could be due to the metric class not being on the same device as input."
                             f"Instead of `metric={self.__class__.__name__}(...)` try to do"
                             f" `metric={self.__class__.__name__}(...).to(device)` where"

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -383,9 +383,9 @@ class Metric(Module, ABC):
                 except RuntimeError as err:
                     if "Expected all tensors to be on" in str(err):
                         raise RuntimeError(
-                            f"{str(err)}. \n"
-                            "Encountered different devices in metric calculation.\n"
-                            "This could be due to the metric class not being on the same device as input.\n"
+                            f"{str(err)}."
+                            "Encountered different devices in metric calculation."
+                            "This could be due to the metric class not being on the same device as input."
                             f"Instead of `metric={self.__class__.__name__}(...)` try to do"
                             f" `metric={self.__class__.__name__}(...).to(device)` where"
                             " device corresponds to the device of the input."

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -380,16 +380,16 @@ class Metric(Module, ABC):
             with torch.set_grad_enabled(self._enable_grad):
                 try:
                     update(*args, **kwargs)
-                except RuntimeError as e:
-                    if "Expected all tensors to be on" in str(e):
+                except RuntimeError as err:
+                    if "Expected all tensors to be on" in str(err):
                         traceback.print_exc()
                         raise RuntimeError(
-                            f"{str(e)}. \n"
+                            f"{str(err)}. \n"
                             "This could be due to the metric class not being on the same device as input.\n"
                             "Instead of `metric=Metric()` try to do `metric=Metric().to(device)` where"
                             " device corresponds to the device of the input."
                         )
-                    raise e
+                    raise err
 
             if self.compute_on_cpu:
                 self._move_list_states_to_cpu()

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -382,9 +382,10 @@ class Metric(Module, ABC):
                 except RuntimeError as err:
                     if "Expected all tensors to be on" in str(err):
                         raise RuntimeError(
-                            f"{str(err)}. \n"
+                            "Encountered different devices in metric calculation.\n"
                             "This could be due to the metric class not being on the same device as input.\n"
-                            "Instead of `metric=Metric()` try to do `metric=Metric().to(device)` where"
+                            f"Instead of `metric={self.__class__.__name__}(...)` try to do"
+                            f" `metric={self.__class__.__name__}(...).to(device)` where"
                             " device corresponds to the device of the input."
                         ) from err
                     raise err

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -383,6 +383,7 @@ class Metric(Module, ABC):
                 except RuntimeError as err:
                     if "Expected all tensors to be on" in str(err):
                         raise RuntimeError(
+                            f"{str(err)}. \n"
                             "Encountered different devices in metric calculation.\n"
                             "This could be due to the metric class not being on the same device as input.\n"
                             f"Instead of `metric={self.__class__.__name__}(...)` try to do"


### PR DESCRIPTION
## What does this PR do?

Fixes #1055, #1047, #917 (And probably a lot more)
Common mistake by users is not moving the metric object to the same device as the input. I think this already pretty clear from the [documentation](https://torchmetrics.readthedocs.io/en/stable/pages/overview.html#metrics-and-devices) (and the fact that metrics are just `nn.Module` which also needs to be moved) but users keep making it. This is a proposed solution that can hopefully catch this mistake.

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
