### PR TITLE
Fix aggregation metrics with zero tensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixed aggregation metrics when input only contains zero ([#1070](https://github.com/PyTorchLightning/metrics/pull/1070))
 
 -
 

--- a/tests/bases/test_aggregation.py
+++ b/tests/bases/test_aggregation.py
@@ -137,6 +137,7 @@ def test_nan_error(value, nan_strategy, metric_class):
         (CatMetric, 2.0, _case1, torch.tensor([2.0, 2.0, 2.0, 2.0, 2.0])),
         (CatMetric, "ignore", _case2, torch.tensor([1.0, 2.0, 4.0, 5.0])),
         (CatMetric, 2.0, _case2, torch.tensor([1.0, 2.0, 2.0, 4.0, 5.0])),
+        (CatMetric, "ignore", torch.zeros(5), torch.zeros(5)),
     ],
 )
 def test_nan_expected(metric_class, nan_strategy, value, expected):

--- a/torchmetrics/aggregation.py
+++ b/torchmetrics/aggregation.py
@@ -43,6 +43,7 @@ class BaseAggregator(Metric):
     value: Tensor
     is_differentiable = None
     higher_is_better = None
+    full_state_update = False
 
     def __init__(
         self,
@@ -116,6 +117,8 @@ class MaxMetric(BaseAggregator):
         tensor(3.)
     """
 
+    full_state_update = True
+
     def __init__(
         self,
         nan_strategy: Union[str, float] = "warn",
@@ -136,7 +139,7 @@ class MaxMetric(BaseAggregator):
                 dimensions will be flattened
         """
         value = self._cast_and_nan_check_input(value)
-        if any(value.flatten()):  # make sure tensor not empty
+        if value.numel() != 0:  # make sure tensor not empty
             self.value = torch.max(self.value, torch.max(value))
 
 
@@ -165,6 +168,8 @@ class MinMetric(BaseAggregator):
         tensor(1.)
     """
 
+    full_state_update = True
+
     def __init__(
         self,
         nan_strategy: Union[str, float] = "warn",
@@ -185,7 +190,7 @@ class MinMetric(BaseAggregator):
                 dimensions will be flattened
         """
         value = self._cast_and_nan_check_input(value)
-        if any(value.flatten()):  # make sure tensor not empty
+        if value.numel() != 0:  # make sure tensor not empty
             self.value = torch.min(self.value, torch.min(value))
 
 
@@ -234,7 +239,8 @@ class SumMetric(BaseAggregator):
                 dimensions will be flattened
         """
         value = self._cast_and_nan_check_input(value)
-        self.value += value.sum()
+        if value.numel() != 0:
+            self.value += value.sum()
 
 
 class CatMetric(BaseAggregator):
@@ -277,7 +283,7 @@ class CatMetric(BaseAggregator):
                 dimensions will be flattened
         """
         value = self._cast_and_nan_check_input(value)
-        if any(value.flatten()):
+        if value.numel() != 0:
             self.value.append(value)
 
     def compute(self) -> Tensor:
@@ -339,17 +345,18 @@ class MeanMetric(BaseAggregator):
         value = self._cast_and_nan_check_input(value)
         weight = self._cast_and_nan_check_input(weight)
 
-        # broadcast weight to values shape
-        if not hasattr(torch, "broadcast_to"):
-            if weight.shape == ():
-                weight = torch.ones_like(value) * weight
-            if weight.shape != value.shape:
-                raise ValueError("Broadcasting not supported on PyTorch <1.8")
-        else:
-            weight = torch.broadcast_to(weight, value.shape)
+        if value.numel() != 0:
+            # broadcast weight to values shape
+            if not hasattr(torch, "broadcast_to"):
+                if weight.shape == ():
+                    weight = torch.ones_like(value) * weight
+                if weight.shape != value.shape:
+                    raise ValueError("Broadcasting not supported on PyTorch <1.8")
+            else:
+                weight = torch.broadcast_to(weight, value.shape)
 
-        self.value += (value * weight).sum()
-        self.weight += weight.sum()
+            self.value += (value * weight).sum()
+            self.weight += weight.sum()
 
     def compute(self) -> Tensor:
         """Compute the aggregated value."""

--- a/torchmetrics/aggregation.py
+++ b/torchmetrics/aggregation.py
@@ -139,7 +139,7 @@ class MaxMetric(BaseAggregator):
                 dimensions will be flattened
         """
         value = self._cast_and_nan_check_input(value)
-        if value.numel() != 0:  # make sure tensor not empty
+        if value.numel():  # make sure tensor not empty
             self.value = torch.max(self.value, torch.max(value))
 
 
@@ -190,7 +190,7 @@ class MinMetric(BaseAggregator):
                 dimensions will be flattened
         """
         value = self._cast_and_nan_check_input(value)
-        if value.numel() != 0:  # make sure tensor not empty
+        if value.numel():  # make sure tensor not empty
             self.value = torch.min(self.value, torch.min(value))
 
 
@@ -239,7 +239,7 @@ class SumMetric(BaseAggregator):
                 dimensions will be flattened
         """
         value = self._cast_and_nan_check_input(value)
-        if value.numel() != 0:
+        if value.numel():
             self.value += value.sum()
 
 
@@ -283,7 +283,7 @@ class CatMetric(BaseAggregator):
                 dimensions will be flattened
         """
         value = self._cast_and_nan_check_input(value)
-        if value.numel() != 0:
+        if value.numel():
             self.value.append(value)
 
     def compute(self) -> Tensor:


### PR DESCRIPTION
## What does this PR do?

Fixes #1063
Change `if any(value)` to `if value.numel() != 0` to check if metric is empty.
Also adds the `full_state_update` to aggregation metrics as it was missing.

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
