### PR TITLE
Fix state reference in `MetricCollection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added specific `RuntimeError` when metric object is on wrong device ([#1056](https://github.com/PyTorchLightning/metrics/pull/1056))
+
+
 - Added an option to specify own n-gram weights for `BLEUScore` and `SacreBLEUScore` instead of using uniform weights only. ([#1075](https://github.com/PyTorchLightning/metrics/pull/1075))
+
 
 -
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `TypeError` when providing superclass arguments as kwargs ([#1069](https://github.com/PyTorchLightning/metrics/pull/1069))
 
 
+- Fixed bug related to state reference in metric collection when using compute groups ([#1076](https://github.com/PyTorchLightning/metrics/pull/1076))
+
+
 ## [0.9.0] - 2022-05-30
 
 ### Added

--- a/integrations/test_lightning.py
+++ b/integrations/test_lightning.py
@@ -19,6 +19,7 @@ from torch import tensor
 from torch.utils.data import DataLoader
 
 from integrations.lightning.boring_model import BoringModel, RandomDataset
+from tests.helpers.utilities import no_warning_call
 from torchmetrics import Accuracy, AveragePrecision, MetricCollection, SumMetric
 
 
@@ -210,7 +211,11 @@ def test_metric_lightning_log(tmpdir):
         max_epochs=2,
         log_every_n_steps=1,
     )
-    trainer.fit(model)
+    with no_warning_call(
+        UserWarning,
+        match="Torchmetrics v0.9 introduced a new argument class property called.*",
+    ):
+        trainer.fit(model)
 
     logged = trainer.logged_metrics
     assert torch.allclose(tensor(logged["sum_step"]), model.sum, atol=2e-4)
@@ -249,7 +254,11 @@ def test_metric_collection_lightning_log(tmpdir):
         log_every_n_steps=1,
         weights_summary=None,
     )
-    trainer.fit(model)
+    with no_warning_call(
+        UserWarning,
+        match="Torchmetrics v0.9 introduced a new argument class property called.*",
+    ):
+        trainer.fit(model)
 
     logged = trainer.logged_metrics
     assert torch.allclose(tensor(logged["SumMetric_epoch"]), model.sum, atol=2e-4)

--- a/tests/bases/test_collections.py
+++ b/tests/bases/test_collections.py
@@ -373,6 +373,8 @@ class TestComputeGroups:
 
     @pytest.mark.parametrize("method", ["items", "values", "keys"])
     def test_check_compute_groups_items_and_values(self, metrics, expected, method):
+        """Check that whenever user call a methods that give access to the indivitual metric that state are copied
+        instead of just passed by reference."""
         m = MetricCollection(deepcopy(metrics), compute_groups=True)
         m2 = MetricCollection(deepcopy(metrics), compute_groups=False)
 

--- a/tests/bases/test_collections.py
+++ b/tests/bases/test_collections.py
@@ -333,9 +333,7 @@ class TestComputeGroups:
         ],
     )
     def test_check_compute_groups_correctness(self, metrics, expected, prefix, postfix):
-        """Check that compute groups are formed after initialization and 
-        that metrics are correctly computed.
-        """
+        """Check that compute groups are formed after initialization and that metrics are correctly computed."""
         m = MetricCollection(deepcopy(metrics), prefix=prefix, postfix=postfix, compute_groups=True)
         # Construct without for comparison
         m2 = MetricCollection(deepcopy(metrics), prefix=prefix, postfix=postfix, compute_groups=False)
@@ -373,30 +371,30 @@ class TestComputeGroups:
             m.reset()
             m2.reset()
 
-    @pytest.mark.parametrize("method", ['items', 'values', 'keys'])
+    @pytest.mark.parametrize("method", ["items", "values", "keys"])
     def test_check_compute_groups_items_and_values(self, metrics, expected, method):
         m = MetricCollection(deepcopy(metrics), compute_groups=True)
         m2 = MetricCollection(deepcopy(metrics), compute_groups=False)
-        
+
         for _ in range(2):  # repeat to emulate effect of multiple epochs
             for _ in range(2):  # repeat to emulate effect of multiple batches
                 preds = torch.randn(10, 3).softmax(dim=-1)
                 target = torch.randint(3, (10,))
                 m.update(preds, target)
                 m2.update(preds, target)
-            
+
             def _compare(m1, m2):
                 for state in m1._defaults:
                     assert torch.allclose(getattr(m1, state), getattr(m2, state))
                 # if states are still by reference the reset will make following metrics fail
                 m1.reset()
                 m2.reset()
-            
-            if method == 'items':
+
+            if method == "items":
                 for (name_cg, metric_cg), (name_no_cg, metric_no_cg) in zip(m.items(), m2.items()):
                     assert name_cg == name_no_cg
                     _compare(metric_cg, metric_no_cg)
-            if method == 'values':
+            if method == "values":
                 for metric_cg, metric_no_cg in zip(m.values(), m2.values()):
                     _compare(metric_cg, metric_no_cg)
             if method == "keys":

--- a/tests/bases/test_collections.py
+++ b/tests/bases/test_collections.py
@@ -322,53 +322,87 @@ def test_collection_filtering():
         ),
     ],
 )
-@pytest.mark.parametrize(
-    "prefix, postfix",
-    [
-        [None, None],
-        ["prefix_", None],
-        [None, "_postfix"],
-        ["prefix_", "_postfix"],
-    ],
-)
-def test_check_compute_groups(metrics, expected, prefix, postfix):
-    """Check that compute groups are formed after initialization."""
-    m = MetricCollection(deepcopy(metrics), prefix=prefix, postfix=postfix, compute_groups=True)
-    # Construct without for comparison
-    m2 = MetricCollection(deepcopy(metrics), prefix=prefix, postfix=postfix, compute_groups=False)
+class TestComputeGroups:
+    @pytest.mark.parametrize(
+        "prefix, postfix",
+        [
+            [None, None],
+            ["prefix_", None],
+            [None, "_postfix"],
+            ["prefix_", "_postfix"],
+        ],
+    )
+    def test_check_compute_groups_correctness(self, metrics, expected, prefix, postfix):
+        """Check that compute groups are formed after initialization and 
+        that metrics are correctly computed.
+        """
+        m = MetricCollection(deepcopy(metrics), prefix=prefix, postfix=postfix, compute_groups=True)
+        # Construct without for comparison
+        m2 = MetricCollection(deepcopy(metrics), prefix=prefix, postfix=postfix, compute_groups=False)
 
-    assert len(m.compute_groups) == len(m)
-    assert m2.compute_groups == {}
-
-    for _ in range(2):  # repeat to emulate effect of multiple epochs
-        preds = torch.randn(10, 3).softmax(dim=-1)
-        target = torch.randint(3, (10,))
-        m.update(preds, target)
-        m2.update(preds, target)
-
-        for _, member in m.items():
-            assert member._update_called
-
-        assert m.compute_groups == expected
+        assert len(m.compute_groups) == len(m)
         assert m2.compute_groups == {}
 
-        preds = torch.randn(10, 3).softmax(dim=-1)
-        target = torch.randint(3, (10,))
-        # compute groups should kick in here
-        m.update(preds, target)
-        m2.update(preds, target)
+        for _ in range(2):  # repeat to emulate effect of multiple epochs
+            preds = torch.randn(10, 3).softmax(dim=-1)
+            target = torch.randint(3, (10,))
+            m.update(preds, target)
+            m2.update(preds, target)
 
-        for _, member in m.items():
-            assert member._update_called
+            for _, member in m.items():
+                assert member._update_called
 
-        # compare results for correctness
-        res_cg = m.compute()
-        res_without_cg = m2.compute()
-        for key in res_cg.keys():
-            assert torch.allclose(res_cg[key], res_without_cg[key])
+            assert m.compute_groups == expected
+            assert m2.compute_groups == {}
 
-        m.reset()
-        m2.reset()
+            preds = torch.randn(10, 3).softmax(dim=-1)
+            target = torch.randint(3, (10,))
+            # compute groups should kick in here
+            m.update(preds, target)
+            m2.update(preds, target)
+
+            for _, member in m.items():
+                assert member._update_called
+
+            # compare results for correctness
+            res_cg = m.compute()
+            res_without_cg = m2.compute()
+            for key in res_cg.keys():
+                assert torch.allclose(res_cg[key], res_without_cg[key])
+
+            m.reset()
+            m2.reset()
+
+    @pytest.mark.parametrize("method", ['items', 'values', 'keys'])
+    def test_check_compute_groups_items_and_values(self, metrics, expected, method):
+        m = MetricCollection(deepcopy(metrics), compute_groups=True)
+        m2 = MetricCollection(deepcopy(metrics), compute_groups=False)
+        
+        for _ in range(2):  # repeat to emulate effect of multiple epochs
+            for _ in range(2):  # repeat to emulate effect of multiple batches
+                preds = torch.randn(10, 3).softmax(dim=-1)
+                target = torch.randint(3, (10,))
+                m.update(preds, target)
+                m2.update(preds, target)
+            
+            def _compare(m1, m2):
+                for state in m1._defaults:
+                    assert torch.allclose(getattr(m1, state), getattr(m2, state))
+                # if states are still by reference the reset will make following metrics fail
+                m1.reset()
+                m2.reset()
+            
+            if method == 'items':
+                for (name_cg, metric_cg), (name_no_cg, metric_no_cg) in zip(m.items(), m2.items()):
+                    assert name_cg == name_no_cg
+                    _compare(metric_cg, metric_no_cg)
+            if method == 'values':
+                for metric_cg, metric_no_cg in zip(m.values(), m2.values()):
+                    _compare(metric_cg, metric_no_cg)
+            if method == "keys":
+                for key in m.keys():
+                    metric_cg, metric_no_cg = m[key], m2[key]
+                    _compare(metric_cg, metric_no_cg)
 
 
 @pytest.mark.parametrize(

--- a/tests/bases/test_metric.py
+++ b/tests/bases/test_metric.py
@@ -26,6 +26,7 @@ from torch.nn import Module
 from tests.helpers import seed_all
 from tests.helpers.testers import DummyListMetric, DummyMetric, DummyMetricMultiOutput, DummyMetricSum
 from tests.helpers.utilities import no_warning_call
+from torchmetrics import PearsonCorrCoef
 from torchmetrics.utilities.imports import _TORCH_LOWER_1_6
 
 seed_all(42)
@@ -424,6 +425,17 @@ def test_warning_on_not_set_full_state_update(metric_class):
         match="Torchmetrics v0.9 introduced a new argument class property called.*",
     ):
         UnsetProperty()
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires gpu")
+def test_specific_error_on_wrong_device():
+    metric = PearsonCorrCoef()
+    preds = torch.tensor(range(10), device="cuda", dtype=torch.float)
+    target = torch.tensor(range(10), device="cuda", dtype=torch.float)
+    with pytest.raises(
+        RuntimeError, match="This could be due to the metric class not being on the same device as input"
+    ):
+        _ = metric(preds, target)
 
 
 @pytest.mark.parametrize("metric_class", [DummyListMetric, DummyMetric, DummyMetricMultiOutput, DummyMetricSum])

--- a/torchmetrics/collections.py
+++ b/torchmetrics/collections.py
@@ -245,7 +245,12 @@ class MetricCollection(ModuleDict):
         return True
 
     def _compute_groups_create_state_ref(self, copy: bool = False) -> None:
-        """Create reference between metrics in the same compute group."""
+        """Create reference between metrics in the same compute group.
+
+        Args:
+            copy: If `True` the metric state will between members will be copied instead
+                of just passed by reference
+        """
         if self._groups_checked:
             for _, cg in self._groups.items():
                 m0 = getattr(self, cg[0])
@@ -404,6 +409,8 @@ class MetricCollection(ModuleDict):
         r"""Return an iterable of the ModuleDict key/value pairs.
         Args:
             keep_base: Whether to add prefix/postfix on the items collection.
+            copy_state: If metric states should be copied between metrics in
+                the same compute group or just passed by reference
         """
         if copy_state:
             self._compute_groups_create_state_ref(copy_state)
@@ -412,11 +419,24 @@ class MetricCollection(ModuleDict):
         return self._to_renamed_ordered_dict().items()
 
     def values(self, copy_state: bool = True) -> Iterable[Module]:
+        """Return an iterable of the ModuleDict values.
+
+        Args:
+            copy_state: If metric states should be copied between metrics in
+                the same compute group or just passed by reference
+        """
         if copy_state:
             self._compute_groups_create_state_ref(copy_state)
         return self._modules.values()
 
     def __getitem__(self, key: str, copy_state: bool = True) -> Module:
+        """Retrieve a single metric from the collection.
+
+        Args:
+            key: name of metric to retrieve
+            copy_state: If metric states should be copied between metrics in
+                the same compute group or just passed by reference
+        """
         if copy_state:
             self._compute_groups_create_state_ref(copy_state)
         return self._modules[key]

--- a/torchmetrics/collections.py
+++ b/torchmetrics/collections.py
@@ -410,7 +410,7 @@ class MetricCollection(ModuleDict):
         if keep_base:
             return self._modules.items()
         return self._to_renamed_ordered_dict().items()
-    
+
     def values(self, copy_state: bool = True) -> Iterable[Module]:
         if copy_state:
             self._compute_groups_create_state_ref(copy_state)

--- a/torchmetrics/collections.py
+++ b/torchmetrics/collections.py
@@ -412,8 +412,8 @@ class MetricCollection(ModuleDict):
         r"""Return an iterable of the ModuleDict key/value pairs.
         Args:
             keep_base: Whether to add prefix/postfix on the items collection.
-            copy_state: If metric states should be copied between metrics in
-                the same compute group or just passed by reference
+            copy_state:
+                If metric states should be copied between metrics in the same compute group or just passed by reference
         """
         self._compute_groups_create_state_ref(copy_state)
         if keep_base:
@@ -424,8 +424,8 @@ class MetricCollection(ModuleDict):
         """Return an iterable of the ModuleDict values.
 
         Args:
-            copy_state: If metric states should be copied between metrics in
-                the same compute group or just passed by reference
+            copy_state:
+                If metric states should be copied between metrics in the same compute group or just passed by reference
         """
         self._compute_groups_create_state_ref(copy_state)
         return self._modules.values()
@@ -435,8 +435,8 @@ class MetricCollection(ModuleDict):
 
         Args:
             key: name of metric to retrieve
-            copy_state: If metric states should be copied between metrics in
-                the same compute group or just passed by reference
+            copy_state:
+                If metric states should be copied between metrics in the same compute group or just passed by reference
         """
         self._compute_groups_create_state_ref(copy_state)
         return self._modules[key]

--- a/torchmetrics/metric.py
+++ b/torchmetrics/metric.py
@@ -303,7 +303,8 @@ class Metric(Module, ABC):
 
         # reduce batch and global state
         self._update_count = _update_count + 1
-        self._reduce_states(global_state)
+        with torch.no_grad():
+            self._reduce_states(global_state)
 
         # restore context
         self._is_synced = False


### PR DESCRIPTION
## What does this PR do?

Fixes #1051 
When users call `.items()`, `.values` or `__getitem__` on a metric collection that have enabled compute groups, the metric states are currently only by referenced, leading to weird results sometimes when metrics in the collection is individually interacted with (as when logging in PL with `self.log`).
PR fixes this by creating copies (instead of references) when needed.

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
