### PR TITLE
typing for kwargs

### DIFF
--- a/torchmetrics/aggregation.py
+++ b/torchmetrics/aggregation.py
@@ -50,7 +50,7 @@ class BaseAggregator(Metric):
         fn: Union[Callable, str],
         default_value: Union[Tensor, List],
         nan_strategy: Union[str, float] = "error",
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__(**kwargs)
         allowed_nan_strategy = ("error", "warn", "ignore")
@@ -122,7 +122,7 @@ class MaxMetric(BaseAggregator):
     def __init__(
         self,
         nan_strategy: Union[str, float] = "warn",
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__(
             "max",
@@ -173,7 +173,7 @@ class MinMetric(BaseAggregator):
     def __init__(
         self,
         nan_strategy: Union[str, float] = "warn",
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__(
             "min",
@@ -222,7 +222,7 @@ class SumMetric(BaseAggregator):
     def __init__(
         self,
         nan_strategy: Union[str, float] = "warn",
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__(
             "sum",
@@ -271,7 +271,7 @@ class CatMetric(BaseAggregator):
     def __init__(
         self,
         nan_strategy: Union[str, float] = "warn",
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__("cat", [], nan_strategy, **kwargs)
 
@@ -321,7 +321,7 @@ class MeanMetric(BaseAggregator):
     def __init__(
         self,
         nan_strategy: Union[str, float] = "warn",
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__(
             "sum",

--- a/torchmetrics/aggregation.py
+++ b/torchmetrics/aggregation.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import warnings
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, List, Union
 
 import torch
 from torch import Tensor

--- a/torchmetrics/audio/pesq.py
+++ b/torchmetrics/audio/pesq.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict
+from typing import Any
 
 from torch import Tensor, tensor
 

--- a/torchmetrics/audio/pesq.py
+++ b/torchmetrics/audio/pesq.py
@@ -80,7 +80,7 @@ class PerceptualEvaluationSpeechQuality(Metric):
         self,
         fs: int,
         mode: str,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         if not _PESQ_AVAILABLE:

--- a/torchmetrics/audio/pit.py
+++ b/torchmetrics/audio/pit.py
@@ -70,7 +70,7 @@ class PermutationInvariantTraining(Metric):
         self,
         metric_func: Callable,
         eval_func: str = "max",
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         base_kwargs: Dict[str, Any] = {
             "dist_sync_on_step": kwargs.pop("dist_sync_on_step", False),

--- a/torchmetrics/audio/sdr.py
+++ b/torchmetrics/audio/sdr.py
@@ -88,7 +88,7 @@ class SignalDistortionRatio(Metric):
         filter_length: int = 512,
         zero_mean: bool = False,
         load_diag: Optional[float] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 
@@ -162,7 +162,7 @@ class ScaleInvariantSignalDistortionRatio(Metric):
     def __init__(
         self,
         zero_mean: bool = False,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.zero_mean = zero_mean

--- a/torchmetrics/audio/sdr.py
+++ b/torchmetrics/audio/sdr.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from torch import Tensor, tensor
 

--- a/torchmetrics/audio/snr.py
+++ b/torchmetrics/audio/snr.py
@@ -69,7 +69,7 @@ class SignalNoiseRatio(Metric):
     def __init__(
         self,
         zero_mean: bool = False,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.zero_mean = zero_mean
@@ -134,7 +134,7 @@ class ScaleInvariantSignalNoiseRatio(Metric):
 
     def __init__(
         self,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/audio/snr.py
+++ b/torchmetrics/audio/snr.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict
+from typing import Any
 
 from torch import Tensor, tensor
 

--- a/torchmetrics/audio/stoi.py
+++ b/torchmetrics/audio/stoi.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict
+from typing import Any
 
 from torch import Tensor, tensor
 

--- a/torchmetrics/audio/stoi.py
+++ b/torchmetrics/audio/stoi.py
@@ -87,7 +87,7 @@ class ShortTimeObjectiveIntelligibility(Metric):
         self,
         fs: int,
         extended: bool = False,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         if not _PYSTOI_AVAILABLE:

--- a/torchmetrics/classification/accuracy.py
+++ b/torchmetrics/classification/accuracy.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from torch import Tensor, tensor
 

--- a/torchmetrics/classification/accuracy.py
+++ b/torchmetrics/classification/accuracy.py
@@ -170,7 +170,7 @@ class Accuracy(StatScores):
         top_k: Optional[int] = None,
         multiclass: Optional[bool] = None,
         subset_accuracy: bool = False,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         allowed_average = ["micro", "macro", "weighted", "samples", "none", None]
         if average not in allowed_average:

--- a/torchmetrics/classification/auc.py
+++ b/torchmetrics/classification/auc.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 from torch import Tensor
 

--- a/torchmetrics/classification/auc.py
+++ b/torchmetrics/classification/auc.py
@@ -44,7 +44,7 @@ class AUC(Metric):
     def __init__(
         self,
         reorder: bool = False,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/classification/auroc.py
+++ b/torchmetrics/classification/auroc.py
@@ -109,7 +109,7 @@ class AUROC(Metric):
         pos_label: Optional[int] = None,
         average: Optional[str] = "macro",
         max_fpr: Optional[float] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/classification/auroc.py
+++ b/torchmetrics/classification/auroc.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 import torch
 from torch import Tensor

--- a/torchmetrics/classification/avg_precision.py
+++ b/torchmetrics/classification/avg_precision.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, List, Optional, Union
 
 import torch
 from torch import Tensor

--- a/torchmetrics/classification/avg_precision.py
+++ b/torchmetrics/classification/avg_precision.py
@@ -89,7 +89,7 @@ class AveragePrecision(Metric):
         num_classes: Optional[int] = None,
         pos_label: Optional[int] = None,
         average: Optional[str] = "macro",
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/classification/binned_precision_recall.py
+++ b/torchmetrics/classification/binned_precision_recall.py
@@ -120,7 +120,7 @@ class BinnedPrecisionRecallCurve(Metric):
         self,
         num_classes: int,
         thresholds: Union[int, Tensor, List[float]] = 100,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 
@@ -281,7 +281,7 @@ class BinnedRecallAtFixedPrecision(BinnedPrecisionRecallCurve):
         num_classes: int,
         min_precision: float,
         thresholds: Union[int, Tensor, List[float]] = 100,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(num_classes=num_classes, thresholds=thresholds, **kwargs)
         self.min_precision = min_precision

--- a/torchmetrics/classification/binned_precision_recall.py
+++ b/torchmetrics/classification/binned_precision_recall.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 import torch
 from torch import Tensor

--- a/torchmetrics/classification/calibration_error.py
+++ b/torchmetrics/classification/calibration_error.py
@@ -66,7 +66,7 @@ class CalibrationError(Metric):
         self,
         n_bins: int = 15,
         norm: str = "l1",
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
 
         super().__init__(**kwargs)

--- a/torchmetrics/classification/calibration_error.py
+++ b/torchmetrics/classification/calibration_error.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List
+from typing import Any, List
 
 import torch
 from torch import Tensor

--- a/torchmetrics/classification/cohen_kappa.py
+++ b/torchmetrics/classification/cohen_kappa.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import torch
 from torch import Tensor

--- a/torchmetrics/classification/cohen_kappa.py
+++ b/torchmetrics/classification/cohen_kappa.py
@@ -77,7 +77,7 @@ class CohenKappa(Metric):
         num_classes: int,
         weights: Optional[str] = None,
         threshold: float = 0.5,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.num_classes = num_classes

--- a/torchmetrics/classification/confusion_matrix.py
+++ b/torchmetrics/classification/confusion_matrix.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import torch
 from torch import Tensor

--- a/torchmetrics/classification/confusion_matrix.py
+++ b/torchmetrics/classification/confusion_matrix.py
@@ -96,7 +96,7 @@ class ConfusionMatrix(Metric):
         normalize: Optional[str] = None,
         threshold: float = 0.5,
         multilabel: bool = False,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.num_classes = num_classes

--- a/torchmetrics/classification/dice.py
+++ b/torchmetrics/classification/dice.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from torch import Tensor
 

--- a/torchmetrics/classification/dice.py
+++ b/torchmetrics/classification/dice.py
@@ -128,7 +128,7 @@ class Dice(StatScores):
         ignore_index: Optional[int] = None,
         top_k: Optional[int] = None,
         multiclass: Optional[bool] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         allowed_average = ("micro", "macro", "weighted", "samples", "none", None)
         if average not in allowed_average:

--- a/torchmetrics/classification/f_beta.py
+++ b/torchmetrics/classification/f_beta.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from torch import Tensor
 

--- a/torchmetrics/classification/f_beta.py
+++ b/torchmetrics/classification/f_beta.py
@@ -130,7 +130,7 @@ class FBetaScore(StatScores):
         ignore_index: Optional[int] = None,
         top_k: Optional[int] = None,
         multiclass: Optional[bool] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         self.beta = beta
         allowed_average = list(AverageMethod)
@@ -256,7 +256,7 @@ class F1Score(FBetaScore):
         ignore_index: Optional[int] = None,
         top_k: Optional[int] = None,
         multiclass: Optional[bool] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(
             num_classes=num_classes,

--- a/torchmetrics/classification/hamming.py
+++ b/torchmetrics/classification/hamming.py
@@ -65,7 +65,7 @@ class HammingDistance(Metric):
     def __init__(
         self,
         threshold: float = 0.5,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/classification/hamming.py
+++ b/torchmetrics/classification/hamming.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict
+from typing import Any
 
 import torch
 from torch import Tensor, tensor

--- a/torchmetrics/classification/hinge.py
+++ b/torchmetrics/classification/hinge.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional, Union
+from typing import Any, Optional, Union
 
 from torch import Tensor, tensor
 

--- a/torchmetrics/classification/hinge.py
+++ b/torchmetrics/classification/hinge.py
@@ -97,7 +97,7 @@ class HingeLoss(Metric):
         self,
         squared: bool = False,
         multiclass_mode: Optional[Union[str, MulticlassMode]] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/classification/jaccard.py
+++ b/torchmetrics/classification/jaccard.py
@@ -88,7 +88,7 @@ class JaccardIndex(ConfusionMatrix):
         absent_score: float = 0.0,
         threshold: float = 0.5,
         multilabel: bool = False,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(
             num_classes=num_classes,

--- a/torchmetrics/classification/jaccard.py
+++ b/torchmetrics/classification/jaccard.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import torch
 from torch import Tensor

--- a/torchmetrics/classification/kl_divergence.py
+++ b/torchmetrics/classification/kl_divergence.py
@@ -74,7 +74,7 @@ class KLDivergence(Metric):
         self,
         log_prob: bool = False,
         reduction: Literal["mean", "sum", "none", None] = "mean",
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         if not isinstance(log_prob, bool):

--- a/torchmetrics/classification/kl_divergence.py
+++ b/torchmetrics/classification/kl_divergence.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict
+from typing import Any
 
 import torch
 from torch import Tensor

--- a/torchmetrics/classification/matthews_corrcoef.py
+++ b/torchmetrics/classification/matthews_corrcoef.py
@@ -72,7 +72,7 @@ class MatthewsCorrCoef(Metric):
         self,
         num_classes: int,
         threshold: float = 0.5,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.num_classes = num_classes

--- a/torchmetrics/classification/matthews_corrcoef.py
+++ b/torchmetrics/classification/matthews_corrcoef.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict
+from typing import Any
 
 import torch
 from torch import Tensor

--- a/torchmetrics/classification/precision_recall.py
+++ b/torchmetrics/classification/precision_recall.py
@@ -121,7 +121,7 @@ class Precision(StatScores):
         ignore_index: Optional[int] = None,
         top_k: Optional[int] = None,
         multiclass: Optional[bool] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         allowed_average = ["micro", "macro", "weighted", "samples", "none", None]
         if average not in allowed_average:
@@ -256,7 +256,7 @@ class Recall(StatScores):
         ignore_index: Optional[int] = None,
         top_k: Optional[int] = None,
         multiclass: Optional[bool] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         allowed_average = ["micro", "macro", "weighted", "samples", "none", None]
         if average not in allowed_average:

--- a/torchmetrics/classification/precision_recall.py
+++ b/torchmetrics/classification/precision_recall.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from torch import Tensor
 

--- a/torchmetrics/classification/precision_recall_curve.py
+++ b/torchmetrics/classification/precision_recall_curve.py
@@ -85,7 +85,7 @@ class PrecisionRecallCurve(Metric):
         self,
         num_classes: Optional[int] = None,
         pos_label: Optional[int] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/classification/precision_recall_curve.py
+++ b/torchmetrics/classification/precision_recall_curve.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 import torch
 from torch import Tensor

--- a/torchmetrics/classification/roc.py
+++ b/torchmetrics/classification/roc.py
@@ -110,7 +110,7 @@ class ROC(Metric):
         self,
         num_classes: Optional[int] = None,
         pos_label: Optional[int] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/classification/roc.py
+++ b/torchmetrics/classification/roc.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 import torch
 from torch import Tensor

--- a/torchmetrics/classification/specificity.py
+++ b/torchmetrics/classification/specificity.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import torch
 from torch import Tensor

--- a/torchmetrics/classification/specificity.py
+++ b/torchmetrics/classification/specificity.py
@@ -123,7 +123,7 @@ class Specificity(StatScores):
         ignore_index: Optional[int] = None,
         top_k: Optional[int] = None,
         multiclass: Optional[bool] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         allowed_average = ["micro", "macro", "weighted", "samples", "none", None]
         if average not in allowed_average:

--- a/torchmetrics/classification/stat_scores.py
+++ b/torchmetrics/classification/stat_scores.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Any, Callable, Optional, Tuple
 
 import torch
 from torch import Tensor

--- a/torchmetrics/classification/stat_scores.py
+++ b/torchmetrics/classification/stat_scores.py
@@ -128,7 +128,7 @@ class StatScores(Metric):
         ignore_index: Optional[int] = None,
         mdmc_reduce: Optional[str] = None,
         multiclass: Optional[bool] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/detection/mean_ap.py
+++ b/torchmetrics/detection/mean_ap.py
@@ -301,7 +301,7 @@ class MeanAveragePrecision(Metric):
         rec_thresholds: Optional[List[float]] = None,
         max_detection_thresholds: Optional[List[int]] = None,
         class_metrics: bool = False,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:  # type: ignore
         super().__init__(**kwargs)
 

--- a/torchmetrics/functional/audio/pit.py
+++ b/torchmetrics/functional/audio/pit.py
@@ -93,7 +93,7 @@ def _find_best_perm_by_exhaustive_method(
 
 
 def permutation_invariant_training(
-    preds: Tensor, target: Tensor, metric_func: Callable, eval_func: str = "max", **kwargs: Dict[str, Any]
+    preds: Tensor, target: Tensor, metric_func: Callable, eval_func: str = "max", **kwargs: Any
 ) -> Tuple[Tensor, Tensor]:
     """Permutation invariant training (PIT). The ``permutation_invariant_training`` implements the famous
     Permutation Invariant Training method.

--- a/torchmetrics/functional/audio/pit.py
+++ b/torchmetrics/functional/audio/pit.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from itertools import permutations
-from typing import Any, Callable, Dict, Tuple, Union
+from typing import Any, Callable, Tuple, Union
 from warnings import warn
 
 import torch

--- a/torchmetrics/image/fid.py
+++ b/torchmetrics/image/fid.py
@@ -208,7 +208,7 @@ class FrechetInceptionDistance(Metric):
         self,
         feature: Union[int, Module] = 2048,
         reset_real_features: bool = True,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/image/fid.py
+++ b/torchmetrics/image/fid.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, List, Optional, Union
 
 import numpy as np
 import torch

--- a/torchmetrics/image/inception.py
+++ b/torchmetrics/image/inception.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, List, Tuple, Union
 
 import torch
 from torch import Tensor

--- a/torchmetrics/image/inception.py
+++ b/torchmetrics/image/inception.py
@@ -98,7 +98,7 @@ class InceptionScore(Metric):
         self,
         feature: Union[str, int, Module] = "logits_unbiased",
         splits: int = 10,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/image/kid.py
+++ b/torchmetrics/image/kid.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 import torch
 from torch import Tensor

--- a/torchmetrics/image/kid.py
+++ b/torchmetrics/image/kid.py
@@ -165,7 +165,7 @@ class KernelInceptionDistance(Metric):
         gamma: Optional[float] = None,  # type: ignore
         coef: float = 1.0,
         reset_real_features: bool = True,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/image/lpip.py
+++ b/torchmetrics/image/lpip.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List
+from typing import Any, List
 
 import torch
 from torch import Tensor

--- a/torchmetrics/image/lpip.py
+++ b/torchmetrics/image/lpip.py
@@ -95,7 +95,7 @@ class LearnedPerceptualImagePatchSimilarity(Metric):
         self,
         net_type: str = "alex",
         reduction: Literal["sum", "mean"] = "mean",
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/image/psnr.py
+++ b/torchmetrics/image/psnr.py
@@ -75,7 +75,7 @@ class PeakSignalNoiseRatio(Metric):
         base: float = 10.0,
         reduction: Literal["elementwise_mean", "sum", "none", None] = "elementwise_mean",
         dim: Optional[Union[int, Tuple[int, ...]]] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/image/psnr.py
+++ b/torchmetrics/image/psnr.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional, Sequence, Tuple, Union
+from typing import Any, Optional, Sequence, Tuple, Union
 
 import torch
 from torch import Tensor, tensor

--- a/torchmetrics/image/ssim.py
+++ b/torchmetrics/image/ssim.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, List, Optional, Sequence, Tuple, Union
 
 from torch import Tensor
 from typing_extensions import Literal

--- a/torchmetrics/image/ssim.py
+++ b/torchmetrics/image/ssim.py
@@ -80,7 +80,7 @@ class StructuralSimilarityIndexMeasure(Metric):
         k2: float = 0.03,
         return_full_image: bool = False,
         return_contrast_sensitivity: bool = False,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         rank_zero_warn(
@@ -198,7 +198,7 @@ class MultiScaleStructuralSimilarityIndexMeasure(Metric):
         k2: float = 0.03,
         betas: Tuple[float, ...] = (0.0448, 0.2856, 0.3001, 0.2363, 0.1333),
         normalize: Literal["relu", "simple", None] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         rank_zero_warn(

--- a/torchmetrics/image/uqi.py
+++ b/torchmetrics/image/uqi.py
@@ -64,7 +64,7 @@ class UniversalImageQualityIndex(Metric):
         sigma: Sequence[float] = (1.5, 1.5),
         reduction: Literal["elementwise_mean", "sum", "none", None] = "elementwise_mean",
         data_range: Optional[float] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         rank_zero_warn(

--- a/torchmetrics/image/uqi.py
+++ b/torchmetrics/image/uqi.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, List, Optional, Sequence
 
 from torch import Tensor
 from typing_extensions import Literal

--- a/torchmetrics/regression/cosine_similarity.py
+++ b/torchmetrics/regression/cosine_similarity.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List
+from typing import Any, List
 
 import torch
 from torch import Tensor

--- a/torchmetrics/regression/cosine_similarity.py
+++ b/torchmetrics/regression/cosine_similarity.py
@@ -60,7 +60,7 @@ class CosineSimilarity(Metric):
     def __init__(
         self,
         reduction: Literal["mean", "sum", "none", None] = "sum",
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         allowed_reduction = ("sum", "mean", "none", None)

--- a/torchmetrics/regression/explained_variance.py
+++ b/torchmetrics/regression/explained_variance.py
@@ -80,7 +80,7 @@ class ExplainedVariance(Metric):
     def __init__(
         self,
         multioutput: str = "uniform_average",
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         allowed_multioutput = ("raw_values", "uniform_average", "variance_weighted")

--- a/torchmetrics/regression/explained_variance.py
+++ b/torchmetrics/regression/explained_variance.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Sequence, Union
+from typing import Any, Sequence, Union
 
 import torch
 from torch import Tensor, tensor

--- a/torchmetrics/regression/log_mse.py
+++ b/torchmetrics/regression/log_mse.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict
+from typing import Any
 
 import torch
 from torch import Tensor, tensor

--- a/torchmetrics/regression/log_mse.py
+++ b/torchmetrics/regression/log_mse.py
@@ -50,7 +50,7 @@ class MeanSquaredLogError(Metric):
 
     def __init__(
         self,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/regression/mae.py
+++ b/torchmetrics/regression/mae.py
@@ -46,7 +46,7 @@ class MeanAbsoluteError(Metric):
 
     def __init__(
         self,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/regression/mae.py
+++ b/torchmetrics/regression/mae.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict
+from typing import Any
 
 import torch
 from torch import Tensor, tensor

--- a/torchmetrics/regression/mape.py
+++ b/torchmetrics/regression/mape.py
@@ -58,7 +58,7 @@ class MeanAbsolutePercentageError(Metric):
 
     def __init__(
         self,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/regression/mape.py
+++ b/torchmetrics/regression/mape.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict
+from typing import Any
 
 import torch
 from torch import Tensor, tensor

--- a/torchmetrics/regression/mse.py
+++ b/torchmetrics/regression/mse.py
@@ -49,7 +49,7 @@ class MeanSquaredError(Metric):
     def __init__(
         self,
         squared: bool = True,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/regression/mse.py
+++ b/torchmetrics/regression/mse.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict
+from typing import Any
 
 import torch
 from torch import Tensor, tensor

--- a/torchmetrics/regression/pearson.py
+++ b/torchmetrics/regression/pearson.py
@@ -102,7 +102,7 @@ class PearsonCorrCoef(Metric):
 
     def __init__(
         self,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/regression/pearson.py
+++ b/torchmetrics/regression/pearson.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List, Tuple
+from typing import Any, List, Tuple
 
 import torch
 from torch import Tensor

--- a/torchmetrics/regression/r2.py
+++ b/torchmetrics/regression/r2.py
@@ -85,7 +85,7 @@ class R2Score(Metric):
         num_outputs: int = 1,
         adjusted: int = 0,
         multioutput: str = "uniform_average",
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/regression/r2.py
+++ b/torchmetrics/regression/r2.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict
+from typing import Any
 
 import torch
 from torch import Tensor, tensor

--- a/torchmetrics/regression/spearman.py
+++ b/torchmetrics/regression/spearman.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List
+from typing import Any, List
 
 import torch
 from torch import Tensor

--- a/torchmetrics/regression/spearman.py
+++ b/torchmetrics/regression/spearman.py
@@ -52,7 +52,7 @@ class SpearmanCorrCoef(Metric):
 
     def __init__(
         self,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         rank_zero_warn(

--- a/torchmetrics/regression/symmetric_mape.py
+++ b/torchmetrics/regression/symmetric_mape.py
@@ -55,7 +55,7 @@ class SymmetricMeanAbsolutePercentageError(Metric):
 
     def __init__(
         self,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
 

--- a/torchmetrics/regression/symmetric_mape.py
+++ b/torchmetrics/regression/symmetric_mape.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict
+from typing import Any
 
 from torch import Tensor, tensor
 

--- a/torchmetrics/regression/tweedie_deviance.py
+++ b/torchmetrics/regression/tweedie_deviance.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict
+from typing import Any
 
 import torch
 from torch import Tensor

--- a/torchmetrics/regression/tweedie_deviance.py
+++ b/torchmetrics/regression/tweedie_deviance.py
@@ -74,7 +74,7 @@ class TweedieDevianceScore(Metric):
     def __init__(
         self,
         power: float = 0.0,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         if 0 < power < 1:

--- a/torchmetrics/retrieval/base.py
+++ b/torchmetrics/retrieval/base.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, List, Optional
 
 import torch
 from torch import Tensor, tensor

--- a/torchmetrics/retrieval/base.py
+++ b/torchmetrics/retrieval/base.py
@@ -74,7 +74,7 @@ class RetrievalMetric(Metric, ABC):
         self,
         empty_target_action: str = "neg",
         ignore_index: Optional[int] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.allow_non_binary_target = False

--- a/torchmetrics/retrieval/fall_out.py
+++ b/torchmetrics/retrieval/fall_out.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 import torch
 from torch import Tensor, tensor

--- a/torchmetrics/retrieval/fall_out.py
+++ b/torchmetrics/retrieval/fall_out.py
@@ -78,7 +78,7 @@ class RetrievalFallOut(RetrievalMetric):
         empty_target_action: str = "pos",
         ignore_index: Optional[int] = None,
         k: Optional[int] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(
             empty_target_action=empty_target_action,

--- a/torchmetrics/retrieval/hit_rate.py
+++ b/torchmetrics/retrieval/hit_rate.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from torch import Tensor, tensor
 

--- a/torchmetrics/retrieval/hit_rate.py
+++ b/torchmetrics/retrieval/hit_rate.py
@@ -76,7 +76,7 @@ class RetrievalHitRate(RetrievalMetric):
         empty_target_action: str = "neg",
         ignore_index: Optional[int] = None,
         k: Optional[int] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(
             empty_target_action=empty_target_action,

--- a/torchmetrics/retrieval/ndcg.py
+++ b/torchmetrics/retrieval/ndcg.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from torch import Tensor, tensor
 

--- a/torchmetrics/retrieval/ndcg.py
+++ b/torchmetrics/retrieval/ndcg.py
@@ -76,7 +76,7 @@ class RetrievalNormalizedDCG(RetrievalMetric):
         empty_target_action: str = "neg",
         ignore_index: Optional[int] = None,
         k: Optional[int] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(
             empty_target_action=empty_target_action,

--- a/torchmetrics/retrieval/precision.py
+++ b/torchmetrics/retrieval/precision.py
@@ -80,7 +80,7 @@ class RetrievalPrecision(RetrievalMetric):
         ignore_index: Optional[int] = None,
         k: Optional[int] = None,
         adaptive_k: bool = False,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(
             empty_target_action=empty_target_action,

--- a/torchmetrics/retrieval/precision.py
+++ b/torchmetrics/retrieval/precision.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from torch import Tensor, tensor
 

--- a/torchmetrics/retrieval/precision_recall_curve.py
+++ b/torchmetrics/retrieval/precision_recall_curve.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional, Tuple
 
 import torch
 from torch import Tensor, tensor

--- a/torchmetrics/retrieval/precision_recall_curve.py
+++ b/torchmetrics/retrieval/precision_recall_curve.py
@@ -125,7 +125,7 @@ class RetrievalPrecisionRecallCurve(Metric):
         adaptive_k: bool = False,
         empty_target_action: str = "neg",
         ignore_index: Optional[int] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.allow_non_binary_target = False
@@ -270,7 +270,7 @@ class RetrievalRecallAtFixedPrecision(RetrievalPrecisionRecallCurve):
         adaptive_k: bool = False,
         empty_target_action: str = "neg",
         ignore_index: Optional[int] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(
             max_k=max_k,

--- a/torchmetrics/retrieval/recall.py
+++ b/torchmetrics/retrieval/recall.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from torch import Tensor, tensor
 

--- a/torchmetrics/retrieval/recall.py
+++ b/torchmetrics/retrieval/recall.py
@@ -75,7 +75,7 @@ class RetrievalRecall(RetrievalMetric):
         empty_target_action: str = "neg",
         ignore_index: Optional[int] = None,
         k: Optional[int] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(
             empty_target_action=empty_target_action,

--- a/torchmetrics/text/bert.py
+++ b/torchmetrics/text/bert.py
@@ -127,7 +127,7 @@ class BERTScore(Metric):
         rescale_with_baseline: bool = False,
         baseline_path: Optional[str] = None,
         baseline_url: Optional[str] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__(**kwargs)
         self.model_name_or_path = model_name_or_path or _DEFAULT_MODEL

--- a/torchmetrics/text/bleu.py
+++ b/torchmetrics/text/bleu.py
@@ -16,7 +16,7 @@
 # Authors: torchtext authors and @sluks
 # Date: 2020-07-18
 # Link: https://pytorch.org/text/_modules/torchtext/data/metrics.html#bleu_score
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Optional, Sequence
 
 import torch
 from torch import Tensor, tensor

--- a/torchmetrics/text/bleu.py
+++ b/torchmetrics/text/bleu.py
@@ -69,7 +69,7 @@ class BLEUScore(Metric):
         n_gram: int = 4,
         smooth: bool = False,
         weights: Optional[Sequence[float]] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__(**kwargs)
         self.n_gram = n_gram

--- a/torchmetrics/text/cer.py
+++ b/torchmetrics/text/cer.py
@@ -64,7 +64,7 @@ class CharErrorRate(Metric):
 
     def __init__(
         self,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__(**kwargs)
         self.add_state("errors", tensor(0, dtype=torch.float), dist_reduce_fx="sum")

--- a/torchmetrics/text/cer.py
+++ b/torchmetrics/text/cer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List, Union
+from typing import Any, List, Union
 
 import torch
 from torch import Tensor, tensor

--- a/torchmetrics/text/chrf.py
+++ b/torchmetrics/text/chrf.py
@@ -96,7 +96,7 @@ class CHRFScore(Metric):
         lowercase: bool = False,
         whitespace: bool = False,
         return_sentence_level_score: bool = False,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__(**kwargs)
 

--- a/torchmetrics/text/eed.py
+++ b/torchmetrics/text/eed.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List, Sequence, Tuple, Union
+from typing import Any, List, Sequence, Tuple, Union
 
 from torch import Tensor, stack
 from typing_extensions import Literal

--- a/torchmetrics/text/eed.py
+++ b/torchmetrics/text/eed.py
@@ -65,7 +65,7 @@ class ExtendedEditDistance(Metric):
         rho: float = 0.3,
         deletion: float = 0.2,
         insertion: float = 1.0,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__(**kwargs)
 

--- a/torchmetrics/text/mer.py
+++ b/torchmetrics/text/mer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List, Union
+from typing import Any, List, Union
 
 import torch
 from torch import Tensor, tensor

--- a/torchmetrics/text/mer.py
+++ b/torchmetrics/text/mer.py
@@ -61,7 +61,7 @@ class MatchErrorRate(Metric):
 
     def __init__(
         self,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__(**kwargs)
         self.add_state("errors", tensor(0, dtype=torch.float), dist_reduce_fx="sum")

--- a/torchmetrics/text/rouge.py
+++ b/torchmetrics/text/rouge.py
@@ -93,7 +93,7 @@ class ROUGEScore(Metric):
         tokenizer: Callable[[str], Sequence[str]] = None,
         accumulate: Literal["avg", "best"] = "best",
         rouge_keys: Union[str, Tuple[str, ...]] = ("rouge1", "rouge2", "rougeL", "rougeLsum"),  # type: ignore
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__(**kwargs)
         if use_stemmer or "rougeLsum" in rouge_keys:

--- a/torchmetrics/text/sacre_bleu.py
+++ b/torchmetrics/text/sacre_bleu.py
@@ -84,7 +84,7 @@ class SacreBLEUScore(BLEUScore):
         tokenize: Literal["none", "13a", "zh", "intl", "char"] = "13a",
         lowercase: bool = False,
         weights: Optional[Sequence[float]] = None,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__(n_gram=n_gram, smooth=smooth, weights=weights, **kwargs)
         if tokenize not in AVAILABLE_TOKENIZERS:

--- a/torchmetrics/text/sacre_bleu.py
+++ b/torchmetrics/text/sacre_bleu.py
@@ -17,7 +17,7 @@
 # Authors: torchtext authors and @sluks
 # Date: 2020-07-18
 # Link: https://pytorch.org/text/_modules/torchtext/data/metrics.html#bleu_score
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Optional, Sequence
 
 from typing_extensions import Literal
 

--- a/torchmetrics/text/squad.py
+++ b/torchmetrics/text/squad.py
@@ -56,7 +56,7 @@ class SQuAD(Metric):
 
     def __init__(
         self,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__(**kwargs)
 

--- a/torchmetrics/text/ter.py
+++ b/torchmetrics/text/ter.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, List, Optional, Sequence, Tuple, Union
 
 import torch
 from torch import Tensor, tensor

--- a/torchmetrics/text/ter.py
+++ b/torchmetrics/text/ter.py
@@ -63,7 +63,7 @@ class TranslationEditRate(Metric):
         lowercase: bool = True,
         asian_support: bool = False,
         return_sentence_level_score: bool = False,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__(**kwargs)
         if not isinstance(normalize, bool):

--- a/torchmetrics/text/wer.py
+++ b/torchmetrics/text/wer.py
@@ -60,7 +60,7 @@ class WordErrorRate(Metric):
 
     def __init__(
         self,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__(**kwargs)
         self.add_state("errors", tensor(0, dtype=torch.float), dist_reduce_fx="sum")

--- a/torchmetrics/text/wer.py
+++ b/torchmetrics/text/wer.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Dict, List, Union
+from typing import Any, List, Union
 
 import torch
 from torch import Tensor, tensor

--- a/torchmetrics/text/wil.py
+++ b/torchmetrics/text/wil.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List, Union
+from typing import Any, List, Union
 
 from torch import Tensor, tensor
 

--- a/torchmetrics/text/wil.py
+++ b/torchmetrics/text/wil.py
@@ -60,7 +60,7 @@ class WordInfoLost(Metric):
 
     def __init__(
         self,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__(**kwargs)
         self.add_state("errors", tensor(0.0), dist_reduce_fx="sum")

--- a/torchmetrics/text/wip.py
+++ b/torchmetrics/text/wip.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List, Union
+from typing import Any, List, Union
 
 from torch import Tensor, tensor
 

--- a/torchmetrics/text/wip.py
+++ b/torchmetrics/text/wip.py
@@ -59,7 +59,7 @@ class WordInfoPreserved(Metric):
 
     def __init__(
         self,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ):
         super().__init__(**kwargs)
         self.add_state("errors", tensor(0.0), dist_reduce_fx="sum")

--- a/torchmetrics/wrappers/bootstrapping.py
+++ b/torchmetrics/wrappers/bootstrapping.py
@@ -91,7 +91,7 @@ class BootStrapper(Metric):
         quantile: Optional[Union[float, Tensor]] = None,
         raw: bool = False,
         sampling_strategy: str = "poisson",
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         if not isinstance(base_metric, Metric):

--- a/torchmetrics/wrappers/minmax.py
+++ b/torchmetrics/wrappers/minmax.py
@@ -57,7 +57,7 @@ class MinMaxMetric(Metric):
     def __init__(
         self,
         base_metric: Metric,
-        **kwargs: Dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         if not isinstance(base_metric, Metric):


### PR DESCRIPTION
## What does this PR do?

Not sure if I miss something, but maybe we have wrong the typing for kwargs as the `Dict[str, Any]` is meant for the structure, so each element is `Any`
I came to this thinking while fixing typing for #1069
See for reference: [Type annotations for *args and **kwargs](https://stackoverflow.com/questions/37031928/type-annotations-for-args-and-kwargs)

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
